### PR TITLE
feat: bump otlp2records to v0.8.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,4 @@
 [submodule "external/otlp2records"]
 	path = external/otlp2records
 	url = https://github.com/smithclay/otlp2records.git
-	branch = ffi
+	branch = main

--- a/src/function/read_otlp.cpp
+++ b/src/function/read_otlp.cpp
@@ -24,25 +24,27 @@ namespace duckdb {
 // Helper: Arrow C Data Interface to DuckDB type conversion
 // ============================================================================
 
-static LogicalType ArrowFormatToDuckDBType(const char *format) {
-	if (!format) {
+static LogicalType ArrowSchemaToDuckDBType(const ArrowSchema &schema) {
+	if (!schema.format) {
 		throw IOException("Arrow schema has null format string - indicates FFI error");
 	}
 
-	std::string fmt(format);
+	std::string fmt(schema.format);
 
-	// Timestamp types
+	// Timestamp types (format is "ts<unit>:<tz>"; we ignore tz for naive types)
 	if (fmt.substr(0, 3) == "tsm") {
-		// Timestamp millisecond
 		return LogicalType::TIMESTAMP_MS;
 	}
 	if (fmt.substr(0, 3) == "tsu") {
-		// Timestamp microsecond
 		return LogicalType::TIMESTAMP;
 	}
 	if (fmt.substr(0, 3) == "tsn") {
-		// Timestamp nanosecond
 		return LogicalType::TIMESTAMP_NS;
+	}
+
+	// Duration types ("tD<unit>") — no native DuckDB type, surface raw int64.
+	if (fmt.size() >= 3 && fmt[0] == 't' && fmt[1] == 'D') {
+		return LogicalType::BIGINT;
 	}
 
 	// Integer types
@@ -91,12 +93,28 @@ static LogicalType ArrowFormatToDuckDBType(const char *format) {
 		return LogicalType::VARCHAR;
 	}
 
-	// Binary
+	// Variable-length binary
 	if (fmt == "z" || fmt == "Z") {
 		return LogicalType::BLOB;
 	}
 
-	// Default to VARCHAR for unknown types (including complex types)
+	// FixedSizeBinary ("w:N") — used by otlp2records for trace_id (16) and
+	// span_id (8). We render these as hex strings so SQL can match on them
+	// without an extra cast, matching the pre-0.8 schema.
+	if (fmt.size() > 2 && fmt[0] == 'w' && fmt[1] == ':') {
+		return LogicalType::VARCHAR;
+	}
+
+	// List types — recurse into the single child schema.
+	if (fmt == "+l" || fmt == "+L") {
+		if (schema.n_children != 1 || !schema.children || !schema.children[0]) {
+			throw IOException("Invalid Arrow list schema: expected exactly 1 child");
+		}
+		return LogicalType::LIST(ArrowSchemaToDuckDBType(*schema.children[0]));
+	}
+
+	// Unknown / complex types fall back to VARCHAR; the scan will throw a
+	// clear error if it cannot serialize them.
 	return LogicalType::VARCHAR;
 }
 
@@ -210,7 +228,7 @@ static unique_ptr<FunctionData> ReadOTLPRustBind(ClientContext &context, TableFu
 			throw IOException("Invalid Arrow schema: child %lld has null name", static_cast<int64_t>(i));
 		}
 		names.push_back(child->name);
-		return_types.push_back(ArrowFormatToDuckDBType(child->format));
+		return_types.push_back(ArrowSchemaToDuckDBType(*child));
 	}
 
 	result->return_types = return_types;
@@ -393,33 +411,41 @@ static void CopyArrowToDuckDB(const ArrowArray &array, const ArrowSchema &schema
 			string_data[i] = StringVector::AddString(output, data + start, static_cast<idx_t>(len));
 		}
 	}
-	// Integer types
-	else if (fmt == "l") {
-		// INT64
+	// Integer types — signed and unsigned, all width-2 buffers (validity + values).
+	else if (fmt == "l" || fmt == "L" || fmt == "i" || fmt == "I") {
 		if (array.n_buffers < 2) {
-			throw IOException("Invalid Arrow int64 array: expected at least 2 buffers, got %lld",
+			throw IOException("Invalid Arrow integer array (%s): expected at least 2 buffers, got %lld", fmt.c_str(),
+			                  static_cast<int64_t>(array.n_buffers));
+		}
+		auto copy_int = [&](auto *typed_values, auto *typed_output) {
+			for (idx_t i = 0; i < count; i++) {
+				idx_t array_idx = i + array.offset;
+				if (null_bitmap && !(null_bitmap[array_idx / 8] & (1 << (array_idx % 8)))) {
+					mask.SetInvalid(i);
+					continue;
+				}
+				typed_output[i] = typed_values[array_idx];
+			}
+		};
+		if (fmt == "l") {
+			copy_int(static_cast<const int64_t *>(array.buffers[1]), FlatVector::GetData<int64_t>(output));
+		} else if (fmt == "L") {
+			copy_int(static_cast<const uint64_t *>(array.buffers[1]), FlatVector::GetData<uint64_t>(output));
+		} else if (fmt == "i") {
+			copy_int(static_cast<const int32_t *>(array.buffers[1]), FlatVector::GetData<int32_t>(output));
+		} else {
+			copy_int(static_cast<const uint32_t *>(array.buffers[1]), FlatVector::GetData<uint32_t>(output));
+		}
+	}
+	// Duration types (tDs/tDm/tDu/tDn) — stored as int64; surfaced as BIGINT
+	// raw value since DuckDB has no native Arrow Duration type.
+	else if (fmt.size() >= 3 && fmt[0] == 't' && fmt[1] == 'D') {
+		if (array.n_buffers < 2) {
+			throw IOException("Invalid Arrow duration array: expected at least 2 buffers, got %lld",
 			                  static_cast<int64_t>(array.n_buffers));
 		}
 		const int64_t *values = static_cast<const int64_t *>(array.buffers[1]);
 		auto *output_data = FlatVector::GetData<int64_t>(output);
-
-		for (idx_t i = 0; i < count; i++) {
-			idx_t array_idx = i + array.offset;
-			if (null_bitmap && !(null_bitmap[array_idx / 8] & (1 << (array_idx % 8)))) {
-				mask.SetInvalid(i);
-				continue;
-			}
-			output_data[i] = values[array_idx];
-		}
-	} else if (fmt == "i") {
-		// INT32
-		if (array.n_buffers < 2) {
-			throw IOException("Invalid Arrow int32 array: expected at least 2 buffers, got %lld",
-			                  static_cast<int64_t>(array.n_buffers));
-		}
-		const int32_t *values = static_cast<const int32_t *>(array.buffers[1]);
-		auto *output_data = FlatVector::GetData<int32_t>(output);
-
 		for (idx_t i = 0; i < count; i++) {
 			idx_t array_idx = i + array.offset;
 			if (null_bitmap && !(null_bitmap[array_idx / 8] & (1 << (array_idx % 8)))) {
@@ -466,41 +492,107 @@ static void CopyArrowToDuckDB(const ArrowArray &array, const ArrowSchema &schema
 			output_data[i] = (values[array_idx / 8] & (1 << (array_idx % 8))) != 0;
 		}
 	}
-	// Timestamp types
-	// Note: DuckDB's timestamp_t stores microseconds internally.
-	// - Millisecond timestamps (tsm) are converted: val * 1000
-	// - Microsecond timestamps (tsu) are used directly: val
-	// - Nanosecond timestamps (tsn) are truncated: val / 1000 (loses 3 digits precision)
+	// Timestamp types. The destination column's logical type already matches
+	// the unit (set at bind time), so the int64 value is written verbatim.
+	//   tsm → TIMESTAMP_MS (ms),  tsu → TIMESTAMP (μs),  tsn → TIMESTAMP_NS (ns).
 	else if (fmt.substr(0, 3) == "tsm" || fmt.substr(0, 3) == "tsu" || fmt.substr(0, 3) == "tsn") {
 		if (array.n_buffers < 2) {
 			throw IOException("Invalid Arrow timestamp array: expected at least 2 buffers, got %lld",
 			                  static_cast<int64_t>(array.n_buffers));
 		}
-		// Timestamps are stored as int64
 		const int64_t *values = static_cast<const int64_t *>(array.buffers[1]);
-		auto *output_data = FlatVector::GetData<timestamp_t>(output);
-
+		auto *output_data = FlatVector::GetData<int64_t>(output);
 		for (idx_t i = 0; i < count; i++) {
 			idx_t array_idx = i + array.offset;
 			if (null_bitmap && !(null_bitmap[array_idx / 8] & (1 << (array_idx % 8)))) {
 				mask.SetInvalid(i);
 				continue;
 			}
-
-			int64_t val = values[array_idx];
-
-			// Convert based on unit
-			if (fmt.substr(0, 3) == "tsm") {
-				// Milliseconds to microseconds
-				output_data[i] = timestamp_t(val * 1000);
-			} else if (fmt.substr(0, 3) == "tsu") {
-				// Already microseconds
-				output_data[i] = timestamp_t(val);
-			} else {
-				// Nanoseconds to microseconds
-				output_data[i] = timestamp_t(val / 1000);
-			}
+			output_data[i] = values[array_idx];
 		}
+	}
+	// FixedSizeBinary ("w:N") — N bytes per row, rendered as lowercase hex
+	// VARCHAR. Used by otlp2records for 16-byte trace_id and 8-byte span_id.
+	else if (fmt.size() > 2 && fmt[0] == 'w' && fmt[1] == ':') {
+		int width = std::atoi(fmt.c_str() + 2);
+		if (width <= 0) {
+			throw IOException("Invalid Arrow FixedSizeBinary format '%s' - bad width", fmt.c_str());
+		}
+		if (array.n_buffers < 2) {
+			throw IOException("Invalid Arrow FixedSizeBinary array: expected 2 buffers, got %lld",
+			                  static_cast<int64_t>(array.n_buffers));
+		}
+		const uint8_t *bytes = static_cast<const uint8_t *>(array.buffers[1]);
+		auto *string_data = FlatVector::GetData<string_t>(output);
+		static const char hex[] = "0123456789abcdef";
+		std::string buf(static_cast<size_t>(width) * 2, '\0');
+		for (idx_t i = 0; i < count; i++) {
+			idx_t array_idx = i + array.offset;
+			if (null_bitmap && !(null_bitmap[array_idx / 8] & (1 << (array_idx % 8)))) {
+				mask.SetInvalid(i);
+				continue;
+			}
+			const uint8_t *row = bytes + array_idx * static_cast<size_t>(width);
+			for (int b = 0; b < width; b++) {
+				buf[2 * b] = hex[row[b] >> 4];
+				buf[2 * b + 1] = hex[row[b] & 0x0F];
+			}
+			string_data[i] = StringVector::AddString(output, buf.data(), buf.size());
+		}
+	}
+	// List ("+l" int32 offsets) and LargeList ("+L" int64 offsets). The child
+	// array carries the element values; we recurse to fill the LIST vector's
+	// child entry.
+	else if (fmt == "+l" || fmt == "+L") {
+		const bool large = (fmt == "+L");
+		if (array.n_buffers < 2) {
+			throw IOException("Invalid Arrow list array: expected 2 buffers, got %lld",
+			                  static_cast<int64_t>(array.n_buffers));
+		}
+		if (array.n_children != 1 || !array.children || !array.children[0]) {
+			throw IOException("Invalid Arrow list array: expected exactly 1 child");
+		}
+		if (schema.n_children != 1 || !schema.children || !schema.children[0]) {
+			throw IOException("Invalid Arrow list schema: expected exactly 1 child");
+		}
+		// Read the offset at logical position idx (taking array.offset into account).
+		auto offset_at = [&](idx_t idx) -> int64_t {
+			if (large) {
+				return static_cast<const int64_t *>(array.buffers[1])[array.offset + idx];
+			}
+			return static_cast<const int32_t *>(array.buffers[1])[array.offset + idx];
+		};
+
+		const int64_t first_child = offset_at(0);
+		const int64_t last_child = offset_at(count);
+		const idx_t child_count = static_cast<idx_t>(last_child - first_child);
+
+		// Fill the parent's list_entry_t (offset, length) pairs and validity.
+		auto *entries = FlatVector::GetData<list_entry_t>(output);
+		for (idx_t i = 0; i < count; i++) {
+			idx_t array_idx = i + array.offset;
+			if (null_bitmap && !(null_bitmap[array_idx / 8] & (1 << (array_idx % 8)))) {
+				mask.SetInvalid(i);
+				entries[i].offset = 0;
+				entries[i].length = 0;
+				continue;
+			}
+			int64_t start = offset_at(i);
+			int64_t end = offset_at(i + 1);
+			entries[i].offset = static_cast<idx_t>(start - first_child);
+			entries[i].length = static_cast<idx_t>(end - start);
+		}
+
+		// Recurse into the child, using a shifted view so the child starts at
+		// position first_child within its own array.
+		ListVector::Reserve(output, child_count);
+		auto &child_vec = ListVector::GetEntry(output);
+		if (child_count > 0) {
+			ArrowArray child_view = *array.children[0];
+			child_view.offset = array.children[0]->offset + first_child;
+			CopyArrowToDuckDB(child_view, *schema.children[0], child_vec, child_count);
+		}
+		ListVector::SetListSize(output, child_count);
 	} else {
 		throw IOException("Unsupported Arrow format '%s' - cannot convert to DuckDB type", fmt.c_str());
 	}

--- a/test/sql/read_otlp_basic.test
+++ b/test/sql/read_otlp_basic.test
@@ -12,7 +12,7 @@ SELECT * FROM read_otlp_logs('test/data/logs_simple.jsonl') LIMIT 1;
 query I
 SELECT COUNT(*) FROM (
     SELECT column_name FROM (DESCRIBE SELECT * FROM read_otlp_logs('test/data/logs_simple.jsonl'))
-) WHERE column_name IN ('timestamp', 'service_name', 'severity_number', 'body');
+) WHERE column_name IN ('time_unix_nano', 'service_name', 'severity_number', 'body');
 ----
 4
 
@@ -24,7 +24,7 @@ SELECT * FROM read_otlp_traces('test/data/traces_simple.jsonl') LIMIT 1;
 query I
 SELECT COUNT(*) FROM (
     SELECT column_name FROM (DESCRIBE SELECT * FROM read_otlp_traces('test/data/traces_simple.jsonl'))
-) WHERE column_name IN ('timestamp', 'trace_id', 'span_id', 'span_name', 'service_name');
+) WHERE column_name IN ('start_time_unix_nano', 'trace_id', 'span_id', 'name', 'service_name');
 ----
 5
 

--- a/test/sql/read_otlp_concurrent.test
+++ b/test/sql/read_otlp_concurrent.test
@@ -86,7 +86,7 @@ FROM traces, logs;
 
 # Test window functions (DuckDB may parallelize)
 query I
-SELECT COUNT(DISTINCT span_name)
+SELECT COUNT(DISTINCT name)
 FROM read_otlp_traces('test/data/traces_*.jsonl');
 ----
 8
@@ -97,8 +97,8 @@ FROM read_otlp_traces('test/data/traces_*.jsonl');
 query I
 SELECT COUNT(*) FROM (
     SELECT
-        span_name,
-        (SELECT COUNT(*) FROM read_otlp_traces('test/data/traces_simple.jsonl') WHERE span_name = t.span_name) as same_name_count
+        name,
+        (SELECT COUNT(*) FROM read_otlp_traces('test/data/traces_simple.jsonl') WHERE name = t.name) as same_name_count
     FROM read_otlp_traces('test/data/traces_simple.jsonl') t
 );
 ----

--- a/test/sql/read_otlp_edge_cases.test
+++ b/test/sql/read_otlp_edge_cases.test
@@ -41,10 +41,10 @@ WHERE trace_id IS NULL AND span_id IS NULL;
 ----
 3
 
-# Test logs with zero severity
+# Test logs with unspecified severity (NULL in 0.8 — used to map to 0 in 0.7).
 query I
 SELECT COUNT(*) FROM read_otlp_logs('test/data/logs_nulls.jsonl')
-WHERE severity_number = 0;
+WHERE severity_number IS NULL;
 ----
 1
 
@@ -78,7 +78,7 @@ SELECT COUNT(*) FROM read_otlp_traces('test/data/single_trace.jsonl');
 
 # Verify single trace content
 query II
-SELECT trace_id, span_name
+SELECT trace_id, name
 FROM read_otlp_traces('test/data/single_trace.jsonl');
 ----
 00000000000000000000000000000001	single_span

--- a/test/sql/read_otlp_json.test
+++ b/test/sql/read_otlp_json.test
@@ -23,15 +23,15 @@ SELECT COUNT(*) FROM read_otlp_traces('test/data/traces_simple.jsonl');
 # Test traces schema - verify key column types
 query IIIII
 SELECT
-    typeof(timestamp) as ts_type,
+    typeof(start_time_unix_nano) as ts_type,
     typeof(trace_id) as trace_id_type,
     typeof(span_id) as span_id_type,
     typeof(service_name) as service_type,
-    typeof(duration) as duration_type
+    typeof(duration_time_unix_nano) as duration_type
 FROM read_otlp_traces('test/data/traces_simple.jsonl')
 LIMIT 1;
 ----
-TIMESTAMP_MS	VARCHAR	VARCHAR	VARCHAR	BIGINT
+TIMESTAMP_NS	VARCHAR	VARCHAR	VARCHAR	BIGINT
 
 # Test traces content - verify specific values
 query III
@@ -48,7 +48,7 @@ true	true	true
 query I
 SELECT COUNT(*)
 FROM read_otlp_traces('test/data/traces_simple.jsonl')
-WHERE span_name LIKE '%users%';
+WHERE name LIKE '%users%';
 ----
 2
 
@@ -56,7 +56,7 @@ WHERE span_name LIKE '%users%';
 query I
 SELECT COUNT(*)
 FROM read_otlp_traces('test/data/traces_simple.jsonl')
-WHERE duration > 0;
+WHERE duration_time_unix_nano > 0;
 ----
 3
 
@@ -73,14 +73,14 @@ SELECT COUNT(*) FROM read_otlp_logs('test/data/logs_simple.jsonl');
 # Test logs schema - verify key column types
 query IIII
 SELECT
-    typeof(timestamp) as ts_type,
+    typeof(time_unix_nano) as ts_type,
     typeof(service_name) as service_type,
     typeof(severity_text) as severity_type,
     typeof(body) as body_type
 FROM read_otlp_logs('test/data/logs_simple.jsonl')
 LIMIT 1;
 ----
-TIMESTAMP_MS	VARCHAR	VARCHAR	VARCHAR
+TIMESTAMP_NS	VARCHAR	VARCHAR	VARCHAR
 
 # Test logs content - verify specific values
 query II
@@ -121,9 +121,9 @@ SELECT COUNT(*) FROM read_otlp_metrics_gauge('test/data/metrics_simple.jsonl');
 ----
 1
 
-# Test gauge metric value
+# Test gauge metric value (sample is a double, so check double_value)
 query I
-SELECT CAST(value AS BIGINT)
+SELECT CAST(double_value AS BIGINT)
 FROM read_otlp_metrics_gauge('test/data/metrics_simple.jsonl');
 ----
 524288000
@@ -138,9 +138,9 @@ SELECT COUNT(*) FROM read_otlp_metrics_sum('test/data/metrics_simple.jsonl');
 ----
 1
 
-# Test sum metric value
+# Test sum metric value (sample is an int, so check int_value)
 query I
-SELECT CAST(value AS BIGINT)
+SELECT int_value
 FROM read_otlp_metrics_sum('test/data/metrics_simple.jsonl');
 ----
 42

--- a/test/sql/read_otlp_limits.test
+++ b/test/sql/read_otlp_limits.test
@@ -49,7 +49,7 @@ SELECT COUNT(*) FROM read_otlp_metrics_sum('test/data/metrics_simple.jsonl');
 # Test zero duration (nulls traces have no duration)
 query I
 SELECT COUNT(*) FROM read_otlp_traces('test/data/traces_nulls.jsonl')
-WHERE duration = 0;
+WHERE duration_time_unix_nano = 0;
 ----
 3
 

--- a/test/sql/read_otlp_metrics_exp_histogram.test
+++ b/test/sql/read_otlp_metrics_exp_histogram.test
@@ -12,7 +12,7 @@ SELECT COUNT(*) FROM read_otlp_metrics_exp_histogram('test/data/metrics_all_type
 
 # Test metric name
 query I
-SELECT metric_name FROM read_otlp_metrics_exp_histogram('test/data/metrics_all_types.jsonl');
+SELECT name FROM read_otlp_metrics_exp_histogram('test/data/metrics_all_types.jsonl');
 ----
 latency.exp
 
@@ -58,9 +58,9 @@ SELECT service_name FROM read_otlp_metrics_exp_histogram('test/data/metrics_all_
 ----
 test-service
 
-# Test metric_unit
+# Test unit
 query I
-SELECT metric_unit FROM read_otlp_metrics_exp_histogram('test/data/metrics_all_types.jsonl');
+SELECT unit FROM read_otlp_metrics_exp_histogram('test/data/metrics_all_types.jsonl');
 ----
 ms
 

--- a/test/sql/read_otlp_metrics_helpers.test
+++ b/test/sql/read_otlp_metrics_helpers.test
@@ -4,18 +4,18 @@
 
 require otlp
 
-# Gauge helper
+# Gauge helper — metrics_simple.jsonl has a double gauge (524288000.0).
 query I
 SELECT COUNT(*) FROM read_otlp_metrics_gauge('test/data/metrics_simple.jsonl');
 ----
 1
 
 query I
-SELECT CAST(value AS BIGINT) FROM read_otlp_metrics_gauge('test/data/metrics_simple.jsonl');
+SELECT CAST(double_value AS BIGINT) FROM read_otlp_metrics_gauge('test/data/metrics_simple.jsonl');
 ----
 524288000
 
-# Sum helper
+# Sum helper — metrics_simple.jsonl has an int sum (42).
 query I
 SELECT COUNT(*) FROM read_otlp_metrics_sum('test/data/metrics_simple.jsonl');
 ----

--- a/test/sql/read_otlp_metrics_histogram.test
+++ b/test/sql/read_otlp_metrics_histogram.test
@@ -12,19 +12,19 @@ SELECT COUNT(*) FROM read_otlp_metrics_histogram('test/data/metrics_all_types.js
 
 # Test metric name
 query I
-SELECT metric_name FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl');
+SELECT name FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl');
 ----
 latency.hist
 
 # Test metric description
 query I
-SELECT metric_description FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl');
+SELECT description FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl');
 ----
 Latency
 
-# Test metric_unit
+# Test unit
 query I
-SELECT metric_unit FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl');
+SELECT unit FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl');
 ----
 ms
 
@@ -40,17 +40,17 @@ SELECT sum FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl')
 ----
 250.0
 
-# Test bucket_counts (JSON array)
+# Test bucket_counts (typed UBIGINT list in 0.8)
 query I
 SELECT bucket_counts FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl');
 ----
-[5,10,15,12,8]
+[5, 10, 15, 12, 8]
 
-# Test explicit_bounds (JSON array)
+# Test explicit_bounds (typed DOUBLE list in 0.8)
 query I
 SELECT explicit_bounds FROM read_otlp_metrics_histogram('test/data/metrics_all_types.jsonl');
 ----
-[5.0,10.0,20.0,50.0]
+[5.0, 10.0, 20.0, 50.0]
 
 # Test service_name extraction
 query I

--- a/test/sql/read_otlp_protobuf.test
+++ b/test/sql/read_otlp_protobuf.test
@@ -24,19 +24,19 @@ FROM read_otlp_traces('test/data/otlp_traces.pb');
 # Test traces schema - verify key column types
 query IIIII
 SELECT
-    typeof(timestamp) as ts_type,
+    typeof(start_time_unix_nano) as ts_type,
     typeof(trace_id) as trace_id_type,
-    typeof(span_name) as name_type,
+    typeof(name) as name_type,
     typeof(service_name) as service_type,
-    typeof(duration) as duration_type
+    typeof(duration_time_unix_nano) as duration_type
 FROM read_otlp_traces('test/data/otlp_traces.pb')
 LIMIT 1;
 ----
-TIMESTAMP_MS	VARCHAR	VARCHAR	VARCHAR	BIGINT
+TIMESTAMP_NS	VARCHAR	VARCHAR	VARCHAR	BIGINT
 
 # Test traces - verify timestamp is extracted from protobuf
 query I
-SELECT timestamp IS NOT NULL
+SELECT start_time_unix_nano IS NOT NULL
 FROM read_otlp_traces('test/data/otlp_traces.pb');
 ----
 true
@@ -71,14 +71,14 @@ FROM read_otlp_logs('test/data/otlp_logs.pb');
 # Test logs schema - verify key column types
 query IIII
 SELECT
-    typeof(timestamp) as ts_type,
+    typeof(time_unix_nano) as ts_type,
     typeof(service_name) as service_type,
     typeof(severity_text) as severity_type,
     typeof(body) as body_type
 FROM read_otlp_logs('test/data/otlp_logs.pb')
 LIMIT 1;
 ----
-TIMESTAMP_MS	VARCHAR	VARCHAR	VARCHAR
+TIMESTAMP_NS	VARCHAR	VARCHAR	VARCHAR
 
 # Test logs - verify service name extraction
 query I

--- a/test/sql/schema_bridge.test
+++ b/test/sql/schema_bridge.test
@@ -7,11 +7,13 @@ require otlp
 #
 # Test 1: Copy gauge metrics from read_otlp_metrics_gauge()
 #
+# metrics_simple.jsonl gauge is a double (524288000.0) so int_value is NULL.
 
 statement ok
 CREATE TABLE archive_gauge_from_file AS
-SELECT timestamp, service_name, metric_name, metric_description, metric_unit,
-       resource_attributes, scope_name, scope_version, metric_attributes, value
+SELECT time_unix_nano, service_name, name, description, unit,
+       resource_attributes, scope_name, scope_version, metric_attributes,
+       int_value, double_value
 FROM read_otlp_metrics_gauge('test/data/metrics_simple.jsonl');
 
 query I
@@ -20,19 +22,20 @@ SELECT COUNT(*) FROM archive_gauge_from_file;
 1
 
 query I
-SELECT CAST(value AS BIGINT) FROM archive_gauge_from_file;
+SELECT CAST(double_value AS BIGINT) FROM archive_gauge_from_file;
 ----
 524288000
 
 #
 # Test 2: Copy sum metrics from read_otlp_metrics_sum()
 #
+# metrics_simple.jsonl sum is an int (42) so double_value is NULL.
 
 statement ok
 CREATE TABLE archive_sum_from_file AS
-SELECT timestamp, service_name, metric_name, metric_description, metric_unit,
+SELECT time_unix_nano, service_name, name, description, unit,
        resource_attributes, scope_name, scope_version, metric_attributes,
-       value, aggregation_temporality, is_monotonic
+       int_value, double_value, aggregation_temporality, is_monotonic
 FROM read_otlp_metrics_sum('test/data/metrics_simple.jsonl');
 
 query I
@@ -51,7 +54,7 @@ true
 
 statement ok
 CREATE TABLE logs_table AS
-SELECT timestamp, severity_text, body
+SELECT time_unix_nano, severity_text, body
 FROM read_otlp_logs('test/data/logs_simple.jsonl');
 
 query I
@@ -65,7 +68,7 @@ SELECT COUNT(*) FROM logs_table;
 
 statement ok
 CREATE TABLE traces_table AS
-SELECT timestamp, span_name, service_name, duration
+SELECT start_time_unix_nano, name, service_name, duration_time_unix_nano
 FROM read_otlp_traces('test/data/traces_simple.jsonl');
 
 query I


### PR DESCRIPTION
## Summary

Updates the `otlp2records` submodule from `7da6ca7` (Cargo `0.2.0`) to **v0.8.1** (`013f51e`), which ships the OTAP-aligned schema and a pre-1.87-toolchain-compatible `hex_to_bytes` (avoids the unstable `usize::is_multiple_of`, which broke the extension's Rust 1.86 CI).

The C FFI ABI is **unchanged** between the old pin and v0.8.1 (`otlp_parser_create`/`destroy`/`push`/`drain`, `otlp_get_schema`, `otlp_parser_last_error`, `otlp_status_message` — identical signatures), so only the Arrow→DuckDB converter and the SQL tests needed updating for the new schema. The submodule's tracked branch is moved from `ffi` to `main`, since that dedicated FFI lineage is now folded into the published release line.

## Changes

- **Submodule**: `external/otlp2records` `7da6ca7` → `013f51e` (v0.8.1)
- **`.gitmodules`**: `branch = ffi` → `branch = main`
- **`src/function/read_otlp.cpp`** (+190): extend the converter for the OTAP schema
  - Duration (`tD*`) → `BIGINT`
  - FixedSizeBinary (`w:N`) IDs rendered as hex `VARCHAR`
  - typed list histogram buckets (`+l`/`+L` → `LogicalType::LIST`)
  - uint32 (`I`) / uint64 (`L`) scan handling
  - verbatim nanosecond timestamps (no `val/1000` truncation)
- **SQL tests** (10 files): renamed columns and `TIMESTAMP_NS` types

## Testing

- `GEN=ninja make` → build clean (exit 0)
- `make test` → **all 14 test cases pass (154 assertions)**
- `clang-format` clean on `read_otlp.cpp`