### PR TITLE
docs: add local ducklake agent trace image guide

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*
+!docker/
+!docker/duckdb-otlp-server/
+!docker/duckdb-otlp-server/entrypoint.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,55 @@
+name: Docker Image
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  IMAGE_NAME: ghcr.io/${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and publish server image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v') }}
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=sha-
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/duckdb-otlp-server/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # DuckDB OpenTelemetry Extension
 
-Query OpenTelemetry traces, logs, and metrics with SQL, or run an embedded OTLP/HTTP endpoint that streams live telemetry into DuckDB, DuckLake, or Iceberg.
+Query OpenTelemetry traces, logs, and metrics with SQL, or run an embedded HTTP endpoint that streams live telemetry into a local or remote DuckDB, DuckLake, or Iceberg catalog.
 
-`duckdb-otlp` reads OTLP JSON, JSONL, and protobuf file exports from the OpenTelemetry Collector, with row schemas inspired by the [OpenTelemetry ClickHouse exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/clickhouseexporter/README.md). Native builds also include live HTTP ingest for `/v1/logs`, `/v1/traces`, and `/v1/metrics`.
+`duckdb-otlp` reads OTLP JSON, JSONL, and protobuf file exports from the OpenTelemetry Collector. Native builds also include live HTTP ingest for `/v1/logs`, `/v1/traces`, and `/v1/metrics`.
 
 ## Quickstart
 
-Install and load the extension:
+Install and load the extension in a `duckdb` v1.5.3 or higher session:
 
 ```sql
 INSTALL otlp FROM community;
@@ -16,27 +16,28 @@ LOAD otlp;
 Read OTLP data from files:
 
 ```sql
-SELECT timestamp, service_name, severity_text, body
-FROM read_otlp_logs('test/data/logs_simple.jsonl');
+SELECT timestamp, service_name, severity_text, body FROM read_otlp_logs('https://github.com/smithclay/duckdb-otlp/raw/refs/heads/main/test/data/otlp_logs.pb');
 
-SELECT trace_id, span_name, duration / 1000000 AS duration_ms
-FROM read_otlp_traces('test/data/traces_simple.jsonl')
-ORDER BY duration DESC;
+SELECT trace_id, span_name, duration / 1000000 AS duration_ms FROM read_otlp_traces('https://github.com/smithclay/duckdb-otlp/raw/refs/heads/main/test/data/otlp_traces.pb') ORDER BY duration DESC;
 ```
 
-Stream one OTLP log into DuckDB over HTTP:
+Send one OTLP log into DuckDB over the embedded HTTP service:
 
 ```sql
-SELECT listen_url
-FROM otlp_serve('otlp:localhost:4318', token := 'dev-token-123456');
+-- Start the server
+otlp_serve('otlp:localhost:4318', token := 'dev-token-123456');
 ```
+
+In a separate window:
 
 ```bash
 curl -sS http://localhost:4318/v1/logs -H 'Authorization: Bearer dev-token-123456' -H 'Content-Type: application/json' -d '{"resourceLogs":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"curl-demo"}}]},"scopeLogs":[{"logRecords":[{"timeUnixNano":"1704067200000000000","severityText":"INFO","body":{"stringValue":"hello from curl"}}]}]}]}'
 ```
 
+Back in duckdb:
+
 ```sql
--- Normal shutdown commits any remaining buffered rows.
+-- Stop server, flush all buffered data.
 SELECT status FROM otlp_stop('otlp:localhost:4318');
 SELECT timestamp, service_name, severity_text, body FROM otlp_logs;
 ```
@@ -44,6 +45,10 @@ SELECT timestamp, service_name, severity_text, body FROM otlp_logs;
 Live ingest commits buffered rows automatically in the background, currently after about 5 seconds for the oldest buffered row or about 64 MiB of admitted request-body bytes. `otlp_flush` is only needed when you want accepted rows durable/queryable immediately while the server keeps running.
 
 For a full walkthrough, including lakehouse ingest, see the [documentation site](https://smithclay.github.io/duckdb-otlp/).
+
+## Schema
+
+Schema is are generally aligned with a normalized version of [OpenTelemetry Arrow Data model](https://github.com/open-telemetry/otel-arrow/blob/main/docs/data_model.md) as of extension release `v0.5.0`. There are breaking schema changes between `v0.4.0` and `v0.5.0` releases.
 
 ## What You Can Do
 
@@ -59,6 +64,7 @@ For a full walkthrough, including lakehouse ingest, see the [documentation site]
 - [Get Started](https://smithclay.github.io/duckdb-otlp/get-started/)
 - [Live Ingest Quickstart](https://smithclay.github.io/duckdb-otlp/quickstart/serve/)
 - [Stream to DuckLake](https://smithclay.github.io/duckdb-otlp/guides/stream-to-ducklake/)
+- [Store Claude Code or Codex Traces in Local DuckLake](https://smithclay.github.io/duckdb-otlp/guides/store-agent-traces-local-ducklake/)
 - [Stream to Iceberg](https://smithclay.github.io/duckdb-otlp/guides/stream-to-iceberg/)
 - [How-to Guides](https://smithclay.github.io/duckdb-otlp/guides/)
 - [API Reference](https://smithclay.github.io/duckdb-otlp/reference/api/)

--- a/docker/duckdb-otlp-server/Dockerfile
+++ b/docker/duckdb-otlp-server/Dockerfile
@@ -1,0 +1,44 @@
+FROM debian:bookworm-slim
+
+ARG DUCKDB_VERSION=v1.5.3
+ARG TARGETARCH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        unzip \
+        zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    case "${TARGETARCH:-amd64}" in \
+        amd64) duckdb_arch="amd64" ;; \
+        arm64) duckdb_arch="arm64" ;; \
+        *) echo "unsupported TARGETARCH=${TARGETARCH}" >&2; exit 1 ;; \
+    esac; \
+    curl -fsSL \
+        "https://github.com/duckdb/duckdb/releases/download/${DUCKDB_VERSION}/duckdb_cli-linux-${duckdb_arch}.zip" \
+        -o /tmp/duckdb.zip; \
+    unzip /tmp/duckdb.zip -d /usr/local/bin; \
+    chmod +x /usr/local/bin/duckdb; \
+    rm -f /tmp/duckdb.zip
+
+RUN duckdb -unsigned -c "INSTALL ducklake;" \
+    && duckdb -unsigned -c "INSTALL otlp FROM 'https://smithclay.github.io/duckdb-otlp';"
+
+COPY docker/duckdb-otlp-server/entrypoint.sh /usr/local/bin/duckdb-otlp-server
+
+RUN chmod +x /usr/local/bin/duckdb-otlp-server \
+    && mkdir -p /data
+
+LABEL org.opencontainers.image.title="duckdb-otlp server" \
+      org.opencontainers.image.description="DuckDB OTLP/HTTP ingest server writing to a local DuckLake volume" \
+      org.opencontainers.image.source="https://github.com/smithclay/duckdb-otlp"
+
+EXPOSE 4318
+VOLUME ["/data"]
+HEALTHCHECK --interval=10s --timeout=3s --start-period=15s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:4318/healthz >/dev/null || exit 1
+
+ENTRYPOINT ["duckdb-otlp-server"]

--- a/docker/duckdb-otlp-server/entrypoint.sh
+++ b/docker/duckdb-otlp-server/entrypoint.sh
@@ -1,0 +1,56 @@
+#!/bin/sh
+set -eu
+
+DATA_DIR="${DUCKDB_OTLP_DATA_DIR:-/data}"
+DATABASE="${DUCKDB_OTLP_DATABASE:-:memory:}"
+LISTEN_URI="${DUCKDB_OTLP_LISTEN_URI:-otlp:0.0.0.0:4318}"
+TOKEN="${DUCKDB_OTLP_TOKEN:-dev-otlp-token-123456}"
+SCHEMA="${DUCKDB_OTLP_SCHEMA:-main}"
+CONTROL_FIFO="${DUCKDB_OTLP_CONTROL_FIFO:-/tmp/duckdb-otlp.sql}"
+
+sql_escape() {
+    printf "%s" "$1" | sed "s/'/''/g"
+}
+
+DATA_DIR_SQL=$(sql_escape "$DATA_DIR")
+LISTEN_URI_SQL=$(sql_escape "$LISTEN_URI")
+TOKEN_SQL=$(sql_escape "$TOKEN")
+SCHEMA_SQL=$(sql_escape "$SCHEMA")
+
+mkdir -p "$DATA_DIR/files"
+rm -f "$CONTROL_FIFO"
+mkfifo "$CONTROL_FIFO"
+
+duckdb -unsigned "$DATABASE" < "$CONTROL_FIFO" &
+duckdb_pid=$!
+
+exec 3> "$CONTROL_FIFO"
+
+cat >&3 <<SQL
+INSTALL ducklake;
+LOAD ducklake;
+LOAD otlp;
+ATTACH 'ducklake:${DATA_DIR_SQL}/metadata.ducklake' AS lake (DATA_PATH '${DATA_DIR_SQL}/files/');
+SELECT listen_url, auth_token, catalog_name
+FROM otlp_serve(
+    '${LISTEN_URI_SQL}',
+    catalog := 'lake',
+    schema := '${SCHEMA_SQL}',
+    token := '${TOKEN_SQL}',
+    allow_other_hostname := true
+);
+SQL
+
+echo "duckdb-otlp listening on ${LISTEN_URI}"
+echo "DuckLake metadata: ${DATA_DIR}/metadata.ducklake"
+echo "DuckLake data path: ${DATA_DIR}/files"
+echo "Control FIFO: ${CONTROL_FIFO}"
+
+stop_server() {
+    echo "Stopping duckdb-otlp..."
+    printf "SELECT status FROM otlp_stop('%s');\n.quit\n" "$LISTEN_URI_SQL" >&3 || true
+    wait "$duckdb_pid" || true
+}
+
+trap stop_server INT TERM
+wait "$duckdb_pid"

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -49,6 +49,7 @@ export default defineConfig({
             { label: 'Filter Logs', link: '/guides/filtering-logs/' },
             { label: 'Work with Metrics', link: '/guides/working-with-metrics/' },
             { label: 'Stream to DuckLake', link: '/guides/stream-to-ducklake/' },
+            { label: 'Store Agent Traces in DuckLake', link: '/guides/store-agent-traces-local-ducklake/' },
             { label: 'Stream to Iceberg', link: '/guides/stream-to-iceberg/' },
             { label: 'Export to Parquet', link: '/guides/exporting-to-parquet/' },
             { label: 'Error Handling', link: '/guides/error-handling/' },

--- a/site/src/content/docs/guides/index.md
+++ b/site/src/content/docs/guides/index.md
@@ -8,6 +8,7 @@ Use these when you already know the task you want to complete.
 - [How to filter logs](filtering-logs/)
 - [How to work with metrics](working-with-metrics/)
 - [How to stream to DuckLake](stream-to-ducklake/)
+- [How to store agent traces in local DuckLake](store-agent-traces-local-ducklake/)
 - [How to stream to Iceberg](stream-to-iceberg/)
 - [How to export telemetry to Parquet](exporting-to-parquet/)
 - [How to handle malformed input](error-handling/)

--- a/site/src/content/docs/guides/store-agent-traces-local-ducklake.md
+++ b/site/src/content/docs/guides/store-agent-traces-local-ducklake.md
@@ -1,0 +1,159 @@
+---
+title: "How to Store Claude Code or Codex Traces in Local DuckLake"
+description: "Export agent OpenTelemetry spans to the duckdb-otlp Docker image and persist them in a local DuckLake volume."
+---
+
+This guide shows you how to run the `duckdb-otlp` server image locally and point Claude Code or Codex at it with OTLP/HTTP. The container listens on `localhost:4318` and writes traces into a DuckLake catalog stored in a Docker volume.
+
+The examples follow the Claude Code [monitoring](https://code.claude.com/docs/en/monitoring-usage) docs and the Codex [observability](https://developers.openai.com/codex/config-advanced#observability-and-telemetry) and [configuration](https://developers.openai.com/codex/config-reference#configtoml) docs.
+
+## Start the Local Writer
+
+Create a Docker volume for DuckLake metadata and Parquet data:
+
+```bash
+docker volume create duckdb-otlp-ducklake
+```
+
+Start the published server image:
+
+```bash
+docker run --rm --name duckdb-otlp \
+  -p 4318:4318 \
+  -v duckdb-otlp-ducklake:/data \
+  -e DUCKDB_OTLP_TOKEN=dev-otlp-token-123456 \
+  ghcr.io/smithclay/duckdb-otlp:latest
+```
+
+This starts `duckdb-otlp` at `http://localhost:4318`. OTLP/HTTP traces are accepted at:
+
+```text
+http://localhost:4318/v1/traces
+```
+
+The local token in this guide is:
+
+```text
+dev-otlp-token-123456
+```
+
+For a different local token, change `DUCKDB_OTLP_TOKEN` and use the same value in the agent exporter headers.
+
+## Export Claude Code Traces
+
+Run Claude Code with tracing enabled and route spans to the local writer:
+
+```bash
+# To make this apply to every Claude Code session, add these to ~/.claude/settings.json
+export CLAUDE_CODE_ENABLE_TELEMETRY=1
+export CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1
+export OTEL_TRACES_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4318/v1/traces
+export OTEL_EXPORTER_OTLP_HEADERS='Authorization=Bearer dev-otlp-token-123456'
+
+claude -p "write one sentence about local trace storage"
+```
+
+If you also want Claude Code events in DuckLake, add the logs exporter before starting Claude Code:
+
+```bash
+export OTEL_LOGS_EXPORTER=otlp
+export OTEL_EXPORTER_OTLP_LOGS_PROTOCOL=http/protobuf
+export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:4318/v1/logs
+```
+
+Leave `OTEL_LOG_USER_PROMPTS`, `OTEL_LOG_TOOL_DETAILS`, `OTEL_LOG_TOOL_CONTENT`, and `OTEL_LOG_RAW_API_BODIES` unset unless you intend to store prompt text, tool details, tool content, or raw API bodies.
+
+## Export Codex Traces
+
+Put telemetry routing in your user-level Codex config, not in a project-local `.codex/config.toml`. Codex ignores `otel` in project-local config.
+
+Edit `~/.codex/config.toml`:
+
+```toml
+[otel]
+environment = "local"
+log_user_prompt = false
+metrics_exporter = "none"
+exporter = { otlp-http = {
+  endpoint = "http://localhost:4318/v1/logs",
+  protocol = "binary",
+  headers = { "Authorization" = "Bearer dev-otlp-token-123456" }
+}}
+trace_exporter = { otlp-http = {
+  endpoint = "http://localhost:4318/v1/traces",
+  protocol = "binary",
+  headers = { "Authorization" = "Bearer dev-otlp-token-123456" }
+}}
+```
+
+Start a new Codex process after editing the config:
+
+```bash
+codex exec "write one sentence about local trace storage"
+```
+
+If you only want spans and not Codex event logs, set `exporter = "none"` and keep the `trace_exporter` block.
+
+## Flush Buffered Telemetry
+
+`duckdb-otlp` buffers accepted rows. Flush before querying a short local run:
+
+```bash
+docker exec duckdb-otlp sh -c \
+  "printf '%s\n' \"SELECT * FROM otlp_flush('otlp:0.0.0.0:4318');\" > /tmp/duckdb-otlp.sql"
+```
+
+## Inspect Stored Traces
+
+Query through the running DuckDB process. The server process owns the DuckLake catalog lock while it is running, so send inspection SQL to the control FIFO instead of attaching the same DuckLake from a second DuckDB process.
+
+```bash
+docker exec duckdb-otlp sh -c \
+  "printf '%s\n' \
+    \"SELECT trace_id, name, service_name, duration_time_unix_nano\" \
+    \"FROM lake.main.otlp_traces\" \
+    \"ORDER BY start_time_unix_nano DESC\" \
+    \"LIMIT 20;\" \
+    > /tmp/duckdb-otlp.sql"
+
+docker logs --tail 80 duckdb-otlp
+```
+
+If you enabled event logs, inspect recent log rows:
+
+```bash
+docker exec duckdb-otlp sh -c \
+  "printf '%s\n' \
+    \"SELECT time_unix_nano, service_name, severity_text, body\" \
+    \"FROM lake.main.otlp_logs\" \
+    \"ORDER BY time_unix_nano DESC\" \
+    \"LIMIT 20;\" \
+    > /tmp/duckdb-otlp.sql"
+
+docker logs --tail 80 duckdb-otlp
+```
+
+## Stop the Writer
+
+Stop the container with `Ctrl-C` if it is attached to your terminal, or run:
+
+```bash
+docker stop duckdb-otlp
+```
+
+The image sends `otlp_stop('otlp:0.0.0.0:4318')` to DuckDB during shutdown so remaining buffered rows are committed before the process exits.
+
+## If No Traces Appear
+
+- Confirm the agent process was started after the telemetry settings were set.
+- Confirm the trace endpoint is `http://localhost:4318/v1/traces`.
+- Confirm the Authorization header uses the same token as `DUCKDB_OTLP_TOKEN`.
+- Flush the writer before querying short sessions.
+- Keep the query window recent enough to include the agent run.
+
+## See also
+
+- [How to stream to DuckLake](../stream-to-ducklake/)
+- [Live Ingest Reference](../../reference/serve/)


### PR DESCRIPTION
## Summary

- Add a lightweight Docker image definition for running the duckdb-otlp OTLP/HTTP server on port 4318 with a local DuckLake volume.
- Publish the image to this repository's GHCR package (`ghcr.io/${{ github.repository }}`) only on manual dispatch or pushed `v*` tags.
- Add a Diataxis how-to guide for storing Claude Code and Codex traces in local DuckLake, including flush and inspection commands.
- Refresh README quickstart/schema text and link to the new guide.

## Notes

The image is a packaging layer: it downloads the DuckDB CLI and installs the existing unsigned extension from the public GitHub Pages extension repository instead of compiling the extension again. DuckDB is started with `-unsigned` because runtime `SET allow_unsigned_extensions = true` is not sufficient for loading the unsigned extension.

## Validation

- `sh -n docker/duckdb-otlp-server/entrypoint.sh`
- `npm run build`
- `docker build -f docker/duckdb-otlp-server/Dockerfile -t duckdb-otlp:local .`
- Local container smoke test on host port `14318`: health check returned `{"status":"ok"}`, sample trace POST returned `{"status":"buffered","rows":3,"batches":1}`, flush/query confirmed `trace_rows = 3`, and `docker stop` ran `otlp_stop` cleanly.