### PR TITLE
docs: update distroless query examples

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -40,7 +40,7 @@ jobs:
       exclude_archs: "wasm_mvp;wasm_threads;linux_amd64_musl"
 
   # Cheap guard so daemon breakage fails on PRs and feature-branch pushes without paying
-  # for the 2-arch QEMU build/publish. Compiles amd64 natively and warms the shared cache
+  # for the 2-arch publish path. Compiles amd64 natively and warms the shared cache
   # that the publish path (daemon-linux) reuses on main.
   daemon-compile:
     name: Compile + config-test daemon (amd64)
@@ -79,24 +79,23 @@ jobs:
   daemon-linux:
     name: Build server daemon (${{ matrix.arch }})
     if: ${{ github.event_name == 'workflow_dispatch' || github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v') }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - arch: amd64
             platform: linux/amd64
+            runner: ubuntu-24.04
           - arch: arm64
             platform: linux/arm64
+            runner: ubuntu-24.04-arm
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/README.md
+++ b/README.md
@@ -31,9 +31,8 @@ You can either run the provider Docker image that automatically runs the extensi
 <details>
 <summary>Run server as a standalone daemon with Docker</summary>
 
-This automatically bootstraps an embedded DuckDB instance with the extension preloaded.
-
 ```sh
+# This automatically bootstraps an embedded DuckDB instance with the extension preloaded.
 mkdir -p data
 
 docker run --rm --name duckdb-otlp \

--- a/site/src/components/docs/QueryCommittedRows.astro
+++ b/site/src/components/docs/QueryCommittedRows.astro
@@ -20,24 +20,41 @@ const selectColumns = includeTimestamp
   : 'service_name, severity_text, body';
 
 const intro = ownershipNote
-  ? `Flush and query through the running container. ${ownershipNote}`
-  : 'Flush and query through the running container:';
+  ? `Flush and query through Quack from a host DuckDB process. ${ownershipNote}`
+  : 'Flush and query through Quack from a host DuckDB process:';
 
-const queryCommand = `docker exec duckdb-otlp sh -c \\
-  "printf '%s\\n' \\
-    \\"SELECT * FROM otlp_flush('otlp:0.0.0.0:4318');\\" \\
-    \\"SELECT ${selectColumns}\\" \\
-    \\"FROM ${table}\\" \\
-    \\"WHERE service_name = '${serviceName}'\\" \\
-    \\"ORDER BY time_unix_nano DESC\\" \\
-    \\"LIMIT 5;\\" \\
-    > /tmp/duckdb-otlp.sql"
+const queryCommand = `duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp`;
+FROM quack_query(
+  'quack:localhost:9494',
+  'SELECT * FROM otlp_flush(''otlp:0.0.0.0:4318'')',
+  token = 'dev-quack-token-123456'
+);
+
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT ${selectColumns}
+  FROM ${table}
+  WHERE service_name = '${serviceName}'
+  ORDER BY time_unix_nano DESC
+  LIMIT 5
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL`;
 ---
 
 <h2 id="query-committed-rows">Query committed rows</h2>
 
 <p>{intro}</p>
+
+<p>
+  The server image is distroless and has no shell or DuckDB CLI, so do not use
+  <code>docker exec ... sh -c</code> for inspection SQL. The examples in this
+  guide enable Quack and publish port <code>9494</code> for this purpose.
+</p>
 
 <Code code={queryCommand} lang="bash" />

--- a/site/src/content/docs/guides/store-agent-traces-local-ducklake.md
+++ b/site/src/content/docs/guides/store-agent-traces-local-ducklake.md
@@ -21,6 +21,10 @@ Create `.env`:
 DUCKDB_MODE=local-ducklake
 DUCKLAKE_NAME=lake
 DUCKDB_OTLP_TOKEN=dev-otlp-token-123456
+
+DUCKDB_QUACK_ENABLED=1
+DUCKDB_QUACK_ADDR=0.0.0.0:9494
+DUCKDB_QUACK_TOKEN=dev-quack-token-123456
 ```
 
 Start the published server image:
@@ -29,6 +33,7 @@ Start the published server image:
 docker run --rm --name duckdb-otlp \
   --env-file .env \
   -p 4318:4318 \
+  -p 9494:9494 \
   -v duckdb-otlp-ducklake:/data \
   ghcr.io/smithclay/duckdb-otlp:latest
 ```
@@ -109,38 +114,58 @@ To collect spans without Codex event logs, set `exporter = "none"` and keep the 
 `duckdb-otlp` buffers accepted rows. Flush before you query a short local run:
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \"SELECT * FROM otlp_flush('otlp:0.0.0.0:4318');\" > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
+
+FROM quack_query(
+  'quack:localhost:9494',
+  'SELECT * FROM otlp_flush(''otlp:0.0.0.0:4318'')',
+  token = 'dev-quack-token-123456'
+);
+SQL
 ```
 
 ## Inspect Stored Traces
 
-Query through the running DuckDB process. The server process owns the DuckLake catalog lock while it runs, so send inspection SQL to the control FIFO instead of attaching the same DuckLake from a second DuckDB process.
+Query through the running DuckDB process with Quack. The server process owns the DuckLake catalog lock while it runs, and the distroless image has no shell or bundled DuckDB CLI, so do not use `docker exec ... sh -c` for inspection SQL.
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \
-    \"SELECT trace_id, name, service_name, duration_time_unix_nano\" \
-    \"FROM lake.main.otlp_traces\" \
-    \"ORDER BY start_time_unix_nano DESC\" \
-    \"LIMIT 20;\" \
-    > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT trace_id, name, service_name, duration_time_unix_nano
+  FROM lake.main.otlp_traces
+  ORDER BY start_time_unix_nano DESC
+  LIMIT 20
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL
 ```
 
 If you enabled event logs, inspect recent log rows:
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \
-    \"SELECT time_unix_nano, service_name, severity_text, body\" \
-    \"FROM lake.main.otlp_logs\" \
-    \"ORDER BY time_unix_nano DESC\" \
-    \"LIMIT 20;\" \
-    > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT time_unix_nano, service_name, severity_text, body
+  FROM lake.main.otlp_logs
+  ORDER BY time_unix_nano DESC
+  LIMIT 20
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL
 ```
 
 ## Stop the Writer

--- a/site/src/content/docs/guides/stream-to-local-ducklake.mdx
+++ b/site/src/content/docs/guides/stream-to-local-ducklake.mdx
@@ -23,6 +23,10 @@ DUCKDB_OTLP_TOKEN=dev-token-123456
 DUCKLAKE_NAME=lake
 DUCKLAKE_CATALOG_PATH=/data/ducklake/catalog.duckdb
 DUCKLAKE_DATA_PATH=/data/ducklake/storage
+
+DUCKDB_QUACK_ENABLED=1
+DUCKDB_QUACK_ADDR=0.0.0.0:9494
+DUCKDB_QUACK_TOKEN=dev-quack-token-123456
 ```
 
 `DUCKLAKE_CATALOG_PATH` stores DuckLake metadata. `DUCKLAKE_DATA_PATH` stores Parquet data files.
@@ -35,6 +39,7 @@ mkdir -p data
 docker run --rm --name duckdb-otlp \
   --env-file .env \
   -p 4318:4318 \
+  -p 9494:9494 \
   -v "$(pwd)/data:/data" \
   ghcr.io/smithclay/duckdb-otlp:latest
 ```
@@ -60,7 +65,7 @@ Leave the container running while clients send OTLP/HTTP requests.
   table="lake.main.otlp_logs"
   serviceName="local-ducklake-demo"
   includeTimestamp
-  ownershipNote="The server process owns the DuckLake catalog while it runs, so send inspection SQL to the container control file."
+  ownershipNote="The server process owns the DuckLake catalog while it runs, and the distroless image has no shell or bundled DuckDB CLI."
 />
 
 <StopCleanly />

--- a/site/src/content/docs/guides/stream-to-r2-data-catalog.mdx
+++ b/site/src/content/docs/guides/stream-to-r2-data-catalog.mdx
@@ -80,6 +80,10 @@ DUCKDB_OTLP_TOKEN=dev-token-123456
 DUCKDB_CATALOG=r2catalog
 DUCKDB_SCHEMA=otlp
 
+DUCKDB_QUACK_ENABLED=1
+DUCKDB_QUACK_ADDR=0.0.0.0:9494
+DUCKDB_QUACK_TOKEN=dev-quack-token-123456
+
 CLOUDFLARE_ACCOUNT_ID=<account-id>
 CLOUDFLARE_R2_BUCKET=<bucket-name>
 CLOUDFLARE_ACCESS_KEY_ID=<r2-s3-access-key-id>
@@ -94,6 +98,7 @@ CLOUDFLARE_CATALOG_TOKEN=<r2-admin-read-write-token>
 docker run --rm --name duckdb-otlp \
   --env-file cloudflare.env \
   -p 4318:4318 \
+  -p 9494:9494 \
   ghcr.io/smithclay/duckdb-otlp:latest
 ```
 
@@ -124,19 +129,26 @@ The container creates these Iceberg tables in the R2 Data Catalog namespace if t
 Drop the Iceberg tables before disabling the catalog and deleting the R2 bucket:
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \
-    \"SELECT status FROM otlp_stop('otlp:0.0.0.0:4318');\" \
-    \"DROP TABLE IF EXISTS r2catalog.otlp.otlp_logs;\" \
-    \"DROP TABLE IF EXISTS r2catalog.otlp.otlp_traces;\" \
-    \"DROP TABLE IF EXISTS r2catalog.otlp.otlp_metrics_gauge;\" \
-    \"DROP TABLE IF EXISTS r2catalog.otlp.otlp_metrics_sum;\" \
-    \"DROP TABLE IF EXISTS r2catalog.otlp.otlp_metrics_histogram;\" \
-    \"DROP TABLE IF EXISTS r2catalog.otlp.otlp_metrics_exp_histogram;\" \
-    \"DETACH r2catalog;\" \
-    > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT status FROM otlp_stop('otlp:0.0.0.0:4318');
+  DROP TABLE IF EXISTS r2catalog.otlp.otlp_logs;
+  DROP TABLE IF EXISTS r2catalog.otlp.otlp_traces;
+  DROP TABLE IF EXISTS r2catalog.otlp.otlp_metrics_gauge;
+  DROP TABLE IF EXISTS r2catalog.otlp.otlp_metrics_sum;
+  DROP TABLE IF EXISTS r2catalog.otlp.otlp_metrics_histogram;
+  DROP TABLE IF EXISTS r2catalog.otlp.otlp_metrics_exp_histogram;
+  DETACH r2catalog;
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL
+
 docker stop duckdb-otlp
 ```
 

--- a/site/src/content/docs/guides/stream-to-remote-ducklake.mdx
+++ b/site/src/content/docs/guides/stream-to-remote-ducklake.mdx
@@ -45,6 +45,10 @@ DUCKDB_OTLP_TOKEN=dev-token-123456
 DUCKLAKE_NAME=lake
 DUCKDB_SCHEMA=otlp
 
+DUCKDB_QUACK_ENABLED=1
+DUCKDB_QUACK_ADDR=0.0.0.0:9494
+DUCKDB_QUACK_TOKEN=dev-quack-token-123456
+
 CLOUDFLARE_ACCOUNT_ID=<account-id>
 CLOUDFLARE_R2_BUCKET=<bucket-name>
 CLOUDFLARE_R2_PREFIX=duckdb-otlp/
@@ -67,6 +71,7 @@ If you use a custom R2 endpoint, add `CLOUDFLARE_R2_ENDPOINT=<endpoint-host>`.
 docker run --rm --name duckdb-otlp \
   --env-file remote-ducklake.env \
   -p 4318:4318 \
+  -p 9494:9494 \
   ghcr.io/smithclay/duckdb-otlp:latest
 ```
 
@@ -90,7 +95,7 @@ Leave the container running while clients send OTLP/HTTP requests.
 <QueryCommittedRows
   table="lake.otlp.otlp_logs"
   serviceName="remote-ducklake-demo"
-  ownershipNote="The server process owns the DuckLake catalog connection while it runs, so send inspection SQL to the container control file."
+  ownershipNote="The server process owns the DuckLake catalog connection while it runs, and the distroless image has no shell or bundled DuckDB CLI."
 />
 
 <StopCleanly cleanupTarget="Neon and R2" />
@@ -100,19 +105,26 @@ Leave the container running while clients send OTLP/HTTP requests.
 Drop the DuckLake tables before deleting the Neon database or R2 bucket:
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \
-    \"SELECT status FROM otlp_stop('otlp:0.0.0.0:4318');\" \
-    \"DROP TABLE IF EXISTS lake.otlp.otlp_logs;\" \
-    \"DROP TABLE IF EXISTS lake.otlp.otlp_traces;\" \
-    \"DROP TABLE IF EXISTS lake.otlp.otlp_metrics_gauge;\" \
-    \"DROP TABLE IF EXISTS lake.otlp.otlp_metrics_sum;\" \
-    \"DROP TABLE IF EXISTS lake.otlp.otlp_metrics_histogram;\" \
-    \"DROP TABLE IF EXISTS lake.otlp.otlp_metrics_exp_histogram;\" \
-    \"DETACH lake;\" \
-    > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT status FROM otlp_stop('otlp:0.0.0.0:4318');
+  DROP TABLE IF EXISTS lake.otlp.otlp_logs;
+  DROP TABLE IF EXISTS lake.otlp.otlp_traces;
+  DROP TABLE IF EXISTS lake.otlp.otlp_metrics_gauge;
+  DROP TABLE IF EXISTS lake.otlp.otlp_metrics_sum;
+  DROP TABLE IF EXISTS lake.otlp.otlp_metrics_histogram;
+  DROP TABLE IF EXISTS lake.otlp.otlp_metrics_exp_histogram;
+  DETACH lake;
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL
+
 docker stop duckdb-otlp
 ```
 

--- a/site/src/content/docs/guides/stream-to-s3-tables.mdx
+++ b/site/src/content/docs/guides/stream-to-s3-tables.mdx
@@ -113,6 +113,10 @@ DUCKDB_OTLP_TOKEN=dev-token-123456
 DUCKDB_CATALOG=s3tables
 DUCKDB_SCHEMA=otlp
 
+DUCKDB_QUACK_ENABLED=1
+DUCKDB_QUACK_ADDR=0.0.0.0:9494
+DUCKDB_QUACK_TOKEN=dev-quack-token-123456
+
 AWS_REGION=us-west-2
 AWS_PROFILE=cli-dev
 S3_TABLES_BUCKET_ARN=<table-bucket-arn>
@@ -128,6 +132,7 @@ Mount your AWS config read-only so DuckDB can use the configured profile:
 docker run --rm --name duckdb-otlp \
   --env-file s3tables.env \
   -p 4318:4318 \
+  -p 9494:9494 \
   -v "$HOME/.aws:/root/.aws:ro" \
   ghcr.io/smithclay/duckdb-otlp:latest
 ```
@@ -159,19 +164,26 @@ The container creates these Iceberg tables in the S3 Tables namespace if they do
 Drop the Iceberg tables before deleting the CloudFormation stack; S3 Tables table buckets cannot be removed while tables remain:
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \
-    \"SELECT status FROM otlp_stop('otlp:0.0.0.0:4318');\" \
-    \"DROP TABLE IF EXISTS s3tables.otlp.otlp_logs;\" \
-    \"DROP TABLE IF EXISTS s3tables.otlp.otlp_traces;\" \
-    \"DROP TABLE IF EXISTS s3tables.otlp.otlp_metrics_gauge;\" \
-    \"DROP TABLE IF EXISTS s3tables.otlp.otlp_metrics_sum;\" \
-    \"DROP TABLE IF EXISTS s3tables.otlp.otlp_metrics_histogram;\" \
-    \"DROP TABLE IF EXISTS s3tables.otlp.otlp_metrics_exp_histogram;\" \
-    \"DETACH s3tables;\" \
-    > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT status FROM otlp_stop('otlp:0.0.0.0:4318');
+  DROP TABLE IF EXISTS s3tables.otlp.otlp_logs;
+  DROP TABLE IF EXISTS s3tables.otlp.otlp_traces;
+  DROP TABLE IF EXISTS s3tables.otlp.otlp_metrics_gauge;
+  DROP TABLE IF EXISTS s3tables.otlp.otlp_metrics_sum;
+  DROP TABLE IF EXISTS s3tables.otlp.otlp_metrics_histogram;
+  DROP TABLE IF EXISTS s3tables.otlp.otlp_metrics_exp_histogram;
+  DETACH s3tables;
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL
+
 docker stop duckdb-otlp
 ```
 

--- a/site/src/content/docs/setup/collector.md
+++ b/site/src/content/docs/setup/collector.md
@@ -16,6 +16,10 @@ DUCKDB_OTLP_TOKEN=dev-token-123456
 DUCKLAKE_NAME=lake
 DUCKLAKE_CATALOG_PATH=/data/ducklake/catalog.duckdb
 DUCKLAKE_DATA_PATH=/data/ducklake/storage
+
+DUCKDB_QUACK_ENABLED=1
+DUCKDB_QUACK_ADDR=0.0.0.0:9494
+DUCKDB_QUACK_TOKEN=dev-quack-token-123456
 EOF
 
 mkdir -p data
@@ -23,6 +27,7 @@ mkdir -p data
 docker run --rm --name duckdb-otlp \
   --env-file .env \
   -p 4318:4318 \
+  -p 9494:9494 \
   -v "$(pwd)/data:/data" \
   ghcr.io/smithclay/duckdb-otlp:latest
 ```
@@ -81,18 +86,31 @@ If the collector itself runs in Docker, use `http://host.docker.internal:4318` f
 Flush buffered telemetry and query through the running `duckdb-otlp` container:
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \
-    \"SELECT * FROM otlp_flush('otlp:0.0.0.0:4318');\" \
-    \"SELECT service_name, name, count(*) AS spans\" \
-    \"FROM lake.main.otlp_traces\" \
-    \"GROUP BY service_name, name\" \
-    \"ORDER BY spans DESC\" \
-    \"LIMIT 20;\" \
-    > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp
+FROM quack_query(
+  'quack:localhost:9494',
+  'SELECT * FROM otlp_flush(''otlp:0.0.0.0:4318'')',
+  token = 'dev-quack-token-123456'
+);
+
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT service_name, name, count(*) AS spans
+  FROM lake.main.otlp_traces
+  GROUP BY service_name, name
+  ORDER BY spans DESC
+  LIMIT 20
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL
 ```
+
+The server image is distroless and has no shell or DuckDB CLI, so run inspection SQL from a host DuckDB process through Quack instead of `docker exec ... sh -c`.
 
 ## Write OTLP Files Instead
 

--- a/site/src/content/docs/setup/otel-demo.md
+++ b/site/src/content/docs/setup/otel-demo.md
@@ -17,6 +17,10 @@ DUCKDB_OTLP_TOKEN=dev-token-123456
 DUCKLAKE_NAME=lake
 DUCKLAKE_CATALOG_PATH=/data/ducklake/catalog.duckdb
 DUCKLAKE_DATA_PATH=/data/ducklake/storage
+
+DUCKDB_QUACK_ENABLED=1
+DUCKDB_QUACK_ADDR=0.0.0.0:9494
+DUCKDB_QUACK_TOKEN=dev-quack-token-123456
 ```
 
 Start the server:
@@ -27,6 +31,7 @@ mkdir -p data
 docker run --rm --name duckdb-otlp \
   --env-file .env \
   -p 4318:4318 \
+  -p 9494:9494 \
   -v "$(pwd)/data:/data" \
   ghcr.io/smithclay/duckdb-otlp:latest
 ```
@@ -91,32 +96,51 @@ http://localhost:8080
 Flush buffered telemetry and query the running `duckdb-otlp` container:
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \
-    \"SELECT * FROM otlp_flush('otlp:0.0.0.0:4318');\" \
-    \"SELECT service_name, name, count(*) AS spans\" \
-    \"FROM lake.main.otlp_traces\" \
-    \"GROUP BY service_name, name\" \
-    \"ORDER BY spans DESC\" \
-    \"LIMIT 20;\" \
-    > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp
+FROM quack_query(
+  'quack:localhost:9494',
+  'SELECT * FROM otlp_flush(''otlp:0.0.0.0:4318'')',
+  token = 'dev-quack-token-123456'
+);
+
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT service_name, name, count(*) AS spans
+  FROM lake.main.otlp_traces
+  GROUP BY service_name, name
+  ORDER BY spans DESC
+  LIMIT 20
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL
 ```
 
 Inspect recent logs:
 
 ```bash
-docker exec duckdb-otlp sh -c \
-  "printf '%s\n' \
-    \"SELECT time_unix_nano, service_name, severity_text, body\" \
-    \"FROM lake.main.otlp_logs\" \
-    \"ORDER BY time_unix_nano DESC\" \
-    \"LIMIT 20;\" \
-    > /tmp/duckdb-otlp.sql"
+duckdb <<'SQL'
+INSTALL quack;
+LOAD quack;
 
-docker logs --tail 80 duckdb-otlp
+FROM quack_query(
+  'quack:localhost:9494',
+  $$
+  SELECT time_unix_nano, service_name, severity_text, body
+  FROM lake.main.otlp_logs
+  ORDER BY time_unix_nano DESC
+  LIMIT 20
+  $$,
+  token = 'dev-quack-token-123456'
+);
+SQL
 ```
+
+The server image is distroless and has no shell or DuckDB CLI, so run inspection SQL from a host DuckDB process through Quack instead of `docker exec ... sh -c`.
 
 ## Stop Cleanly
 


### PR DESCRIPTION
## Summary

- Replace Docker shell/control-file examples with host DuckDB queries over Quack for the distroless server image.
- Enable Quack and publish port 9494 in the affected Docker walkthroughs.
- Include the README formatting edit alongside the docs revisions.

## Why

The current server image is distroless and does not include a shell or bundled DuckDB CLI, so examples using `docker exec duckdb-otlp sh -c ...` are no longer valid. Quack is the supported way to run inspection and cleanup SQL against the live DuckDB process while the container owns the catalog connection.

## Validation

- `git diff --check`
- `npm run check` from `site`
- `npm run build` from `site`