### PR TITLE
docs: add Colab notebook for querying OTLP with the Pages extension

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -8,12 +8,14 @@ on:
       - 'docs/**'
       - 'demo/**'
       - 'site/**'
+      - 'notebooks/**'
       - 'README.md'
   pull_request:
     paths-ignore:
       - 'docs/**'
       - 'demo/**'
       - 'site/**'
+      - 'notebooks/**'
       - 'README.md'
   workflow_dispatch:
 

--- a/notebooks/duckdb_otlp_colab.ipynb
+++ b/notebooks/duckdb_otlp_colab.ipynb
@@ -1,0 +1,179 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Query OpenTelemetry data with DuckDB in Colab\n",
+    "\n",
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/smithclay/duckdb-otlp/blob/main/notebooks/duckdb_otlp_colab.ipynb)\n",
+    "\n",
+    "This notebook loads the [`duckdb-otlp`](https://github.com/smithclay/duckdb-otlp) extension straight from its GitHub Pages\n",
+    "extension repository and uses it to query OpenTelemetry (OTLP) **traces**, **logs**, and **metrics** with plain SQL —\n",
+    "no collector, no database server.\n",
+    "\n",
+    "The extension is **unsigned** (community-built), so we open the connection with `allow_unsigned_extensions` — the Python\n",
+    "equivalent of launching the DuckDB CLI with `duckdb -unsigned`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## 1. Install DuckDB 1.5.3\n\nDuckDB extension binaries are tied to an **exact** DuckDB version, and the `otlp` extension is published for\n`v1.5.3`. Colab ships an older DuckDB (1.3.x), so the cell below installs 1.5.3 to match. If an older DuckDB was\nalready imported into the kernel, the cell restarts the runtime once — just **re-run it** when the session comes back."
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Colab preinstalls an older DuckDB (1.3.x). The otlp extension is published for\n# DuckDB v1.5.3, and extension binaries are pinned to an exact DuckDB version, so\n# install 1.5.3 to match — any other version makes INSTALL request a build that\n# isn't published (the IO Error / 404 you may have hit).\nREQUIRED = \"1.5.3\"\n\nimport importlib.metadata as ilm, subprocess, sys, os\n\ntry:\n    installed = ilm.version(\"duckdb\")\nexcept ilm.PackageNotFoundError:\n    installed = None\nif installed != REQUIRED:\n    subprocess.run([sys.executable, \"-m\", \"pip\", \"install\", \"-q\", f\"duckdb=={REQUIRED}\"], check=True)\n\n# A restart is only needed if an OLD duckdb was already imported into this kernel.\nif \"duckdb\" in sys.modules and sys.modules[\"duckdb\"].__version__ != REQUIRED:\n    print(f\"Installed duckdb {REQUIRED}; restarting runtime — re-run this cell when it returns.\")\n    os.kill(os.getpid(), 9)\n\nimport duckdb\nprint(\"duckdb\", duckdb.__version__)"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Load the `otlp` extension from GitHub Pages\n",
+    "\n",
+    "`smithclay.github.io/duckdb-otlp` hosts an unsigned DuckDB extension repository. We point `INSTALL ... FROM` at it and\n",
+    "load it into a connection that allows unsigned extensions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "PAGES = \"https://smithclay.github.io/duckdb-otlp\"\n",
+    "\n",
+    "# config={'allow_unsigned_extensions': 'true'} == launching the CLI as `duckdb -unsigned`\n",
+    "con = duckdb.connect(config={\"allow_unsigned_extensions\": \"true\"})\n",
+    "con.execute(f\"INSTALL otlp FROM '{PAGES}'; LOAD otlp;\")\n",
+    "print(\"otlp extension loaded\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Grab some sample OTLP data\n",
+    "\n",
+    "The same site ships small OTLP/JSON samples. The `read_otlp_*` table functions read local files, so download them first.\n",
+    "(They also read OTLP **protobuf** — swap in the `.pb` files if you prefer.)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import urllib.request\n",
+    "\n",
+    "SAMPLES = f\"{PAGES}/wasm-demo/samples\"\n",
+    "for name in [\"traces_simple.jsonl\", \"logs_simple.jsonl\", \"metrics_simple.jsonl\"]:\n",
+    "    urllib.request.urlretrieve(f\"{SAMPLES}/{name}\", name)\n",
+    "    print(\"downloaded\", name)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Traces — slowest spans\n",
+    "\n",
+    "`read_otlp_traces` flattens spans into 24 `snake_case` columns. Duration is exposed in nanoseconds as\n",
+    "`duration_time_unix_nano`; divide by `1e6` for milliseconds."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "    SELECT service_name, name AS span_name, kind,\n",
+    "           duration_time_unix_nano / 1e6 AS duration_ms\n",
+    "    FROM read_otlp_traces('traces_simple.jsonl')\n",
+    "    ORDER BY duration_ms DESC\n",
+    "    LIMIT 10\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Logs — count by severity\n",
+    "\n",
+    "`read_otlp_logs` gives 18 columns including `severity_text`, `body`, and trace-correlation fields (`trace_id`, `span_id`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "    SELECT service_name, severity_text, count(*) AS n\n",
+    "    FROM read_otlp_logs('logs_simple.jsonl')\n",
+    "    GROUP BY ALL\n",
+    "    ORDER BY n DESC\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Metrics — gauge values\n",
+    "\n",
+    "Metrics are split by type. `read_otlp_metrics_gauge` carries `int_value` / `double_value`; sums, histograms, and\n",
+    "exponential histograms have their own `read_otlp_metrics_*` functions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "con.sql(\"\"\"\n",
+    "    SELECT service_name, name AS metric_name, unit,\n",
+    "           coalesce(double_value, int_value) AS value\n",
+    "    FROM read_otlp_metrics_gauge('metrics_simple.jsonl')\n",
+    "    LIMIT 10\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Where to go next\n",
+    "\n",
+    "- Point the `read_otlp_*` functions at your own exported OTLP `.json` / `.jsonl` / `.pb` files.\n",
+    "- Other functions: `read_otlp_metrics_sum`, `read_otlp_metrics_histogram`, `read_otlp_metrics_exp_histogram`.\n",
+    "- Docs & schema reference: https://smithclay.github.io/duckdb-otlp\n",
+    "- Source: https://github.com/smithclay/duckdb-otlp"
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "name": "duckdb_otlp_colab.ipynb",
+   "provenance": []
+  },
+  "kernelspec": {
+   "display_name": "Python 3",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
## What

Adds `notebooks/duckdb_otlp_colab.ipynb` — a self-contained Google Colab notebook that:

- Installs **DuckDB 1.5.3** (pinned to match the published extension) and handles Colab's preinstalled DuckDB (1.3.x) by restarting the runtime once when an older DuckDB was already imported.
- Loads the **unsigned `otlp` extension** straight from the GitHub Pages extension repository (`INSTALL otlp FROM 'https://smithclay.github.io/duckdb-otlp'`) on a connection opened with `allow_unsigned_extensions` — the Python equivalent of `duckdb -unsigned`.
- Queries OTLP **traces**, **logs**, and **metrics** with plain SQL against the bundled sample data.
- Includes an **Open in Colab** badge (resolves once merged to `main`).

## Verification

Re-ran the committed cells top-to-bottom on a fresh Colab VM (stock DuckDB 1.3.2):
`install → load → download samples → traces / logs / metrics` all green. Extension is live on Pages for `v1.5.3/linux_amd64`, which is what Colab runs.

## CI

Adds `notebooks/**` to the `paths-ignore` lists for the `push` and `pull_request` triggers in `MainDistributionPipeline.yml`, so notebook-only changes don't kick off the full extension/daemon build.

> Note: if branch protection marks the distribution-pipeline jobs as required status checks, a notebook-only PR will have those checks skipped (not reported) — confirm that won't block merges.