### PR TITLE
ci(pages): exclude Windows extension builds

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,14 @@ jobs:
       ci_tools_version: v1.5.4
       extension_name: otlp
       extra_toolchains: rust
-      exclude_archs: "wasm_mvp;wasm_threads;linux_amd64_musl"
+      # Windows is excluded: through v1.5.3, DuckDB's bundled fmt no longer compiled on any
+      # current GitHub Windows MSVC image (`stdext::checked_array_iterator` removed →
+      # fmt errors C2653/C7525), and bumping extension-ci-tools to the newer
+      # `windows-2025-vs2026` runner did not help (that MSVC is newer still). v1.5.4 has not
+      # been re-validated on Windows, so it stays excluded conservatively. Re-enable by
+      # removing windows_amd64;windows_amd64_mingw once a DuckDB release is confirmed to ship
+      # an MSVC-compatible fmt. Keep this list in sync with MainDistributionPipeline.yml.
+      exclude_archs: "wasm_mvp;wasm_threads;linux_amd64_musl;windows_amd64;windows_amd64_mingw"
 
   extension-package:
     name: package extension repository


### PR DESCRIPTION
The Pages workflow's extension-build job still attempted windows_amd64 and windows_amd64_mingw, both of which fail on the bundled-fmt/MSVC issue already documented in MainDistributionPipeline.yml. Align the exclude_archs list with the main distribution pipeline so manual publish_extension runs skip Windows.