### PR TITLE
ci(pages): exclude Windows builds and package wasm into the extension repository

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -77,13 +77,36 @@ jobs:
           for dir in artifacts/${prefix}*/; do
             arch="$(basename "$dir")"
             arch="${arch#${prefix}}"
+            out="_extension_repository/${DUCKDB_VERSION}/${arch}"
+            mkdir -p "$out"
+
+            # WASM artifacts ship as <name>.duckdb_extension.wasm and are loaded by
+            # duckdb-wasm over plain HTTP. The canonical repository serves them
+            # brotli-compressed with `Content-Encoding: br`, but GitHub Pages cannot set
+            # that header, so publish the wasm binary UNCOMPRESSED: the browser fetch then
+            # hands raw wasm to the loader, exactly like the in-repo wasm demo
+            # (site/public/wasm-demo/) does today.
+            if [[ "$arch" == wasm* ]]; then
+              src="${dir}${EXT_NAME}.duckdb_extension.wasm"
+              if [ ! -f "$src" ]; then
+                echo "::error::no ${EXT_NAME}.duckdb_extension.wasm in ${dir} for ${arch}"
+                exit 1
+              fi
+              # Normalize to the unsigned 256-byte zero signature, then publish raw.
+              cp "$src" work.bin
+              truncate -s -256 work.bin
+              dd if=/dev/zero bs=256 count=1 status=none >> work.bin
+              mv work.bin "${out}/${EXT_NAME}.duckdb_extension.wasm"
+              echo "packaged ${arch} (wasm, uncompressed)"
+              found=$((found + 1))
+              continue
+            fi
+
             src="${dir}${EXT_NAME}.duckdb_extension"
             if [ ! -f "$src" ]; then
               echo "::error::no ${EXT_NAME}.duckdb_extension in ${dir} for ${arch}"
               exit 1
             fi
-            out="_extension_repository/${DUCKDB_VERSION}/${arch}"
-            mkdir -p "$out"
             # Match the official unsigned packaging: replace any existing
             # signature placeholder with the unsigned 256-byte zero signature,
             # then gzip for DuckDB's native extension repository path.
@@ -117,7 +140,7 @@ jobs:
             echo "INSTALL ${EXT_NAME} FROM '${PAGES_BASE_URL}';"
             echo "LOAD ${EXT_NAME};</pre>"
             echo "<h2>Available binaries</h2><ul>"
-            for f in $(cd _extension_repository && find "${DUCKDB_VERSION}" -name '*.duckdb_extension.gz' | sort); do
+            for f in $(cd _extension_repository && find "${DUCKDB_VERSION}" \( -name '*.duckdb_extension.gz' -o -name '*.duckdb_extension.wasm' \) | sort); do
               echo "<li><a href=\"../${f}\">${f}</a></li>"
             done
             echo "</ul>"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,7 +45,14 @@ jobs:
       ci_tools_version: v1.5.4
       extension_name: otlp
       extra_toolchains: rust
-      exclude_archs: "wasm_mvp;wasm_threads;linux_amd64_musl"
+      # Windows is excluded: through v1.5.3, DuckDB's bundled fmt no longer compiled on any
+      # current GitHub Windows MSVC image (`stdext::checked_array_iterator` removed →
+      # fmt errors C2653/C7525), and bumping extension-ci-tools to the newer
+      # `windows-2025-vs2026` runner did not help (that MSVC is newer still). v1.5.4 has not
+      # been re-validated on Windows, so it stays excluded conservatively. Re-enable by
+      # removing windows_amd64;windows_amd64_mingw once a DuckDB release is confirmed to ship
+      # an MSVC-compatible fmt. Keep this list in sync with MainDistributionPipeline.yml.
+      exclude_archs: "wasm_mvp;wasm_threads;linux_amd64_musl;windows_amd64;windows_amd64_mingw"
 
   extension-package:
     name: package extension repository


### PR DESCRIPTION
## Summary

Fixes two CI failures in the **Pages** workflow's extension-publish path (`workflow_dispatch` with `publish_extension: true`, and `release`):

1. **Windows builds fail** — the `extension-build` job still attempted `windows_amd64` and `windows_amd64_mingw`, both of which fail on the bundled-fmt/MSVC issue already documented (and excluded) in `MainDistributionPipeline.yml`. Aligned `pages.yml`'s `exclude_archs` with the main distribution pipeline and carried over the explanatory comment.

2. **wasm_eh packaging fails** — the `extension-package` Assemble loop hardcoded the native filename `otlp.duckdb_extension` and `exit 1`'d on the `wasm_eh` artifact, whose file is `otlp.duckdb_extension.wasm`. This bug was masked until now: the Windows failure short-circuited `extension-build`, so `extension-package` always skipped. Excluding Windows let the job run for the first time and exposed the latent bug.

## What changed

- `exclude_archs` now also excludes `windows_amd64;windows_amd64_mingw` (kept in sync with `MainDistributionPipeline.yml`).
- The Assemble loop now handles wasm artifacts: it normalizes the 256-byte signature footer like native, but publishes the binary **uncompressed** at `<version>/wasm_eh/otlp.duckdb_extension.wasm`.
  - The canonical repository brotli-compresses wasm and serves it with `Content-Encoding: br`, but GitHub Pages cannot set that header — so raw wasm is the correct form for Pages. The browser fetch hands raw bytes to the loader, exactly like the in-repo wasm demo (`site/public/wasm-demo/`) already does.
- The repo index `find` now also lists `*.duckdb_extension.wasm`.

## Verification

- YAML + `bash -n` validated.
- Dry-ran the Assemble loop against the **real 4 MB wasm artifact** plus a fake native artifact:
  - native → `v1.5.4/linux_amd64/otlp.duckdb_extension.gz` (gzipped)
  - wasm → `v1.5.4/wasm_eh/otlp.duckdb_extension.wasm` (uncompressed; output starts with the `\0asm` wasm magic, length preserved)
  - index lists both.

## Caveat

CI only verifies packaging, not the browser runtime path. Whether `INSTALL otlp FROM 'https://smithclay.github.io/duckdb-otlp'` resolves in duckdb-wasm depends on the host being DuckDB v1.5.4 and requesting exactly `<version>/wasm_eh/otlp.duckdb_extension.wasm` (the layout used here, mirroring the native convention). A direct `LOAD "<pages-url>/.../otlp.duckdb_extension.wasm"` is known to work (the demo does this).