### PR TITLE
feat(serve): promote resource/scope attributes to columns at ingest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(EXTENSION_SOURCES
     src/function/read_otlp.cpp
     src/otlp_arrow.cpp
     src/otlp_uri.cpp
+    src/otlp_column_promote.cpp
     src/otlp_server.cpp
     src/otlp_server_http.cpp
     src/otlp_server_grpc.cpp

--- a/site/src/content/docs/reference/performance.md
+++ b/site/src/content/docs/reference/performance.md
@@ -56,6 +56,17 @@ FROM read_otlp_traces('traces/*.jsonl')
 GROUP BY hour, service_name;
 ```
 
+## Promote Hot Attributes
+
+Filtering an attribute that lives inside the `resource_attributes` / `scope_attributes` JSON blob is a full scan — `json_extract_string(...)` has no row-group statistics. If you repeatedly filter or group by a resource/scope attribute (`deployment.environment`, `k8s.namespace.name`, `cloud.region`, ...), have the live server promote it into a real column at ingest so the scanner can prune by min/max:
+
+```sql
+SELECT * FROM otlp_serve('otlp:0.0.0.0:4318', catalog := 'lake',
+    promote_resource_attributes := 'deployment.environment, k8s.namespace.name');
+```
+
+This trades a little ingest work for much cheaper repeated reads. See [Attribute promotion](../serve/#attribute-promotion).
+
 ## Live Ingest
 
 Live ingest buffers accepted rows and commits them in batches. Current native builds commit when the oldest buffered row is about 5 seconds old, or when admitted request-body bytes reach about 64 MiB. Use `otlp_flush` when readers need fresh rows while the server keeps running.

--- a/site/src/content/docs/reference/schemas.md
+++ b/site/src/content/docs/reference/schemas.md
@@ -178,7 +178,7 @@ All gauge columns are included, plus the two sum-specific columns above.
 ## Type system notes
 
 - `trace_id` and `span_id` are VARCHAR hex strings. Use `unhex()` to convert to binary if needed.
-- Attribute columns store JSON strings. Parse with DuckDB's JSON functions: `json_extract(resource_attributes, '$.key')`.
+- Attribute columns store JSON strings. Parse with DuckDB's JSON functions: `json_extract(resource_attributes, '$.key')`. For attributes you filter on often, the live server can promote resource/scope keys into dedicated columns at ingest — see [Attribute promotion](../serve/#attribute-promotion).
 - Timestamps: file readers expose nanosecond timestamp columns such as `time_unix_nano` and `start_time_unix_nano` as `TIMESTAMP_NS`. Live ingest tables keep the same column names but store those values as DuckDB `TIMESTAMP` for catalog compatibility.
 - Events and links are stored as JSON arrays in `events_json` and `links_json`.
 

--- a/site/src/content/docs/reference/serve.md
+++ b/site/src/content/docs/reference/serve.md
@@ -61,6 +61,8 @@ SELECT * FROM otlp_serve('otlp:localhost:4318', catalog := 'lake', token := 'my-
 | `seal_max_age_ms` | BIGINT | `5000` | Request an asynchronous seal when the oldest buffered row reaches this age. Must be greater than zero. |
 | `target_file_size` | UBIGINT | `268435456` (256 MiB) | DuckLake only. **Output** Parquet file size the post-seal `CHECKPOINT` merge bin-packs toward; bounds compaction write amplification (files already at target are left alone). Distinct from `seal_target_bytes`, which is admitted *input* bytes. Must be greater than zero. |
 | `maintenance_retention_ms` | BIGINT | `900000` (15 min) | DuckLake only. How old snapshots and unused data files must be before the post-seal `CHECKPOINT` expires and deletes them (`expire_older_than` / `delete_older_than`). Keep it longer than your longest read; time-travel below this window is unavailable. Must be greater than zero. |
+| `promote_resource_attributes` | VARCHAR | *(none)* | Comma-separated **resource** attribute keys to promote into first-class columns at ingest. See [Attribute promotion](#attribute-promotion). Catalog mode only. |
+| `promote_scope_attributes` | VARCHAR | *(none)* | Comma-separated **scope** attribute keys to promote into first-class columns at ingest. See [Attribute promotion](#attribute-promotion). Catalog mode only. |
 
 **Output columns** (one row):
 
@@ -181,6 +183,7 @@ FROM otlp_server_list();
 | `maintenance_failures_total` | UBIGINT | Failed maintenance passes since startup. |
 | `last_maintenance_age_ms` | BIGINT | Age (ms) since the last successful maintenance pass, or `NULL` if none has run. |
 | `maintenance_last_error` | VARCHAR | Last maintenance error, or `NULL` if none. |
+| `promoted_columns_total` | UBIGINT | Promoted attribute columns per signal table, or `0` when [attribute promotion](#attribute-promotion) is off/disabled. |
 
 Use `is_listening` / `last_error` to detect a dead listener. Use `seal_last_error` to inspect writer failures, such as catalog conflicts. Use `maintenance_runs_total` / `last_maintenance_age_ms` to confirm compaction is keeping up.
 
@@ -210,6 +213,34 @@ Each batch commit writes **one Parquet data file per signal** plus one DuckLake 
   DuckDB's Iceberg REST catalog docs have no useful `CHECKPOINT` maintenance path today. The internal maintenance probe uses generic `CHECKPOINT <catalog>` only. If the catalog reports checkpointing as unsupported, the server disables automatic maintenance for that server and ingest durability continues normally.
 
 - **Plain Parquet export** (`parquet_export_path := '/data/otlp-parquet'` or `parquet_export_path := 's3://bucket/prefix'`): each seal writes the sealed rows straight to `<path>/<table>/year=YYYY/month=MM/day=DD/*.parquet`. The Parquet dataset is the only durable store — no local table copy is kept (a read-only view per signal is created over the files for inspection), and it is mutually exclusive with a `catalog` target. Because a `COPY` is a file write and cannot be rolled back, export is **at-least-once**: a signal that already exported is never re-written, but a seal whose `COPY` fails part-way can re-export that signal's rows on retry, so deduplicate downstream if you need exactly-once. Use this when you want partitioned Parquet without a lakehouse catalog; see [Stream to Parquet](../../guides/stream-to-parquet/).
+
+## Attribute promotion
+
+Resource and scope attributes land as JSON objects in the `resource_attributes` and `scope_attributes` columns (see [Schemas](../schemas/)), so filtering one means a full-scan `json_extract_string(...)` with no row-group pruning. Attribute promotion lifts **operator-named** keys out of that JSON into their own top-level columns at ingest, so the scanner gets per-row-group min/max statistics and can skip files. It is the right tool for the low-cardinality, stable identity attributes you filter and group by most — `service.name` is already a column, but `deployment.environment`, `k8s.namespace.name`, `cloud.region`, and the like are not.
+
+```sql
+SELECT * FROM otlp_serve(
+    'otlp:0.0.0.0:4318',
+    catalog := 'lake',
+    promote_resource_attributes := 'deployment.environment, k8s.namespace.name',
+    promote_scope_attributes    := 'telemetry.sdk.name'
+);
+```
+
+- **Column naming.** Each key becomes `resource_attr_<key>` or `scope_attr_<key>` (non-alphanumeric characters become `_`), e.g. `deployment.environment` → `resource_attr_deployment_environment`, on **all six** signal tables. The columns are added once when the server starts.
+- **The JSON blob is kept.** A promoted column is an accelerator, not a replacement — the original key stays in `resource_attributes`/`scope_attributes`. Rows written *before* a key was promoted read back `NULL` for its column, so query across old and new data with:
+
+  ```sql
+  COALESCE(resource_attr_deployment_environment,
+           json_extract_string(resource_attributes, '$."deployment.environment"'))
+  ```
+
+- **No auto-discovery.** The promoted set is exactly what you list — there is no workload observation or automatic promotion.
+- **Catalog mode only.** Promotion adds real columns via `ALTER TABLE`, so it requires a catalog target (DuckLake). It is ignored under `parquet_export_path`. On an Iceberg REST catalog it works only if the catalog supports `ADD COLUMN`; otherwise the server logs a warning and disables promotion (ingest continues).
+- **Type.** Promoted columns are `VARCHAR` (the JSON-extracted text).
+- `otlp_server_list().promoted_columns_total` reports the promoted column count per signal.
+
+The daemon exposes the same option via `DUCKDB_OTLP_PROMOTE_RESOURCE_ATTRIBUTES` and `DUCKDB_OTLP_PROMOTE_SCOPE_ATTRIBUTES` (comma-separated). The daemon image must have the `json` extension available; if it cannot load it, promotion disables itself with a log.
 
 ## URI scheme
 

--- a/src/include/otlp_column_promote.hpp
+++ b/src/include/otlp_column_promote.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "duckdb.hpp"
+
+#include <functional>
+
+namespace duckdb {
+
+class Connection;
+
+//! User-specified attribute promotion. At ingest the named resource/scope attribute keys are
+//! extracted out of the JSON `resource_attributes` / `scope_attributes` blobs into first-class
+//! VARCHAR columns (`resource_attr_<key>` / `scope_attr_<key>`) so they get zone-map pruning. The
+//! blob is left intact (the residual); any value reconstructs with
+//! `COALESCE(resource_attr_x, json_extract_string(resource_attributes, '$."x"'))`. There is no
+//! auto-discovery: the promoted set is exactly what the operator lists. Catalog mode only.
+struct OtlpPromoteConfig {
+	vector<string> resource_keys;
+	vector<string> scope_keys;
+	bool Enabled() const {
+		return !resource_keys.empty() || !scope_keys.empty();
+	}
+};
+
+//! Applies a fixed, operator-specified attribute promotion. Resolved once at startup; after
+//! Initialize() all state is immutable, so the seal thread reads ProjectionSuffix() and
+//! otlp_server_list reads PromotedColumnsTotal() without locking.
+class OtlpColumnPromoter {
+public:
+	OtlpColumnPromoter(OtlpPromoteConfig config, string catalog_name, string schema_name,
+	                   std::function<void(const string &)> log);
+
+	bool Enabled() const {
+		return enabled;
+	}
+
+	//! Once at startup on the writer connection: ensure `json` is available and
+	//! `ALTER TABLE ADD COLUMN IF NOT EXISTS` every promoted column on every signal table
+	//! (idempotent, so a restart with the same config is a no-op). Best-effort: on failure (catalog
+	//! cannot add columns, json missing) it logs and disables promotion rather than blocking start.
+	void Initialize(Connection &con);
+
+	//! INSERT...SELECT projection suffix, identical for every signal (resource/scope columns are
+	//! common to all signal tables): `, json_extract_string("resource_attributes", '$."k"') AS
+	//! "resource_attr_k", ...`. Empty when disabled.
+	const string &ProjectionSuffix() const {
+		return suffix;
+	}
+
+	//! Number of promoted attribute columns per table (resource + scope), 0 when disabled.
+	idx_t PromotedColumnsTotal() const {
+		return enabled ? promoted_count : 0;
+	}
+
+private:
+	struct Col {
+		string source_column; //! resource_attributes | scope_attributes
+		string attr_key;      //! the OTLP attribute key
+		string target_column; //! resource_attr_<key> | scope_attr_<key>
+	};
+	void Disable(const string &reason);
+
+	OtlpPromoteConfig config;
+	string catalog_name;
+	string schema_name;
+	std::function<void(const string &)> log;
+	vector<Col> columns;
+	string suffix;
+	idx_t promoted_count = 0;
+	bool enabled = false;
+};
+
+} // namespace duckdb

--- a/src/include/otlp_column_promote.hpp
+++ b/src/include/otlp_column_promote.hpp
@@ -47,6 +47,12 @@ public:
 		return suffix;
 	}
 
+	//! INSERT column-list additions parallel to ProjectionSuffix(), e.g. `, "resource_attr_k", ...`,
+	//! so the seal can name the promoted target columns explicitly. Empty when disabled.
+	const string &TargetColumnList() const {
+		return target_list;
+	}
+
 	//! Number of promoted attribute columns per table (resource + scope), 0 when disabled.
 	idx_t PromotedColumnsTotal() const {
 		return enabled ? columns.size() : 0;
@@ -65,6 +71,7 @@ private:
 	std::function<void(const string &)> log;
 	vector<Col> columns;
 	string suffix;
+	string target_list;
 	bool enabled = false;
 };
 

--- a/src/include/otlp_column_promote.hpp
+++ b/src/include/otlp_column_promote.hpp
@@ -49,7 +49,7 @@ public:
 
 	//! Number of promoted attribute columns per table (resource + scope), 0 when disabled.
 	idx_t PromotedColumnsTotal() const {
-		return enabled ? promoted_count : 0;
+		return enabled ? columns.size() : 0;
 	}
 
 private:
@@ -60,13 +60,11 @@ private:
 	};
 	void Disable(const string &reason);
 
-	OtlpPromoteConfig config;
 	string catalog_name;
 	string schema_name;
 	std::function<void(const string &)> log;
 	vector<Col> columns;
 	string suffix;
-	idx_t promoted_count = 0;
 	bool enabled = false;
 };
 

--- a/src/include/otlp_server.hpp
+++ b/src/include/otlp_server.hpp
@@ -432,6 +432,11 @@ private:
 
 	void CreateOrValidateTable(Connection &con, OtlpSignalType signal_type, const string &table_name);
 	void GetSignalColumns(OtlpSignalType signal_type, vector<LogicalType> &types, vector<string> &names);
+	//! Create a TEMP table matching `signal_type`'s schema on the writer connection and append
+	//! `collection` into it. Returns the appended batch count. Shared staging step for the seal
+	//! paths that stage to a temp table before COPY (parquet export) or INSERT...SELECT (promotion).
+	idx_t StageCollectionToTempTable(OtlpSignalType signal_type, ColumnDataCollection &collection,
+	                                 const string &temp_table);
 
 private:
 	weak_ptr<DatabaseInstance> db_ptr;

--- a/src/include/otlp_server.hpp
+++ b/src/include/otlp_server.hpp
@@ -2,6 +2,7 @@
 
 #include "duckdb.hpp"
 
+#include "otlp_column_promote.hpp"
 #include "otlp_ingest_limits.hpp"
 #include "otlp_log.hpp"
 #include "otlp_request.hpp"
@@ -84,6 +85,9 @@ struct OtlpServerConfig {
 	//! decoded buffer heap — decoded columnar size differs from the encoded/compressed
 	//! input size. It is an admission/throughput proxy, not a precise memory bound.
 	idx_t max_buffered_bytes = otlp_limits::DEFAULT_MAX_BUFFERED_BYTES;
+	//! Opt-in attribute promotion: extract these resource/scope attribute keys into first-class
+	//! columns at ingest. Off when both lists are empty. Catalog (non-Parquet-export) mode only.
+	OtlpPromoteConfig promote;
 };
 
 struct OtlpIngestResult {
@@ -223,6 +227,10 @@ public:
 	string MaintenanceLastError() const {
 		std::lock_guard<std::mutex> lock(seal_error_mutex);
 		return maintenance_last_error;
+	}
+	//! Promoted attribute columns per signal table (0 when promotion is disabled).
+	idx_t PromotedColumnsTotal() const {
+		return promoter ? promoter->PromotedColumnsTotal() : 0;
 	}
 	vector<OtlpSealEvent> SealHistory() const;
 
@@ -446,6 +454,9 @@ private:
 	// (sealer thread) against FlushNow (otlp_flush) and the final drain on shutdown.
 	unique_ptr<Connection> writer_con;
 	mutex writer_mutex;
+	//! Attribute promotion (null unless config.promote.Enabled()). Resolved at construction; the
+	//! seal thread only reads its immutable ProjectionSuffix().
+	unique_ptr<OtlpColumnPromoter> promoter;
 	std::thread sealer_thread;
 	std::mutex sealer_mutex;
 	std::condition_variable sealer_cv;

--- a/src/include/otlp_server.hpp
+++ b/src/include/otlp_server.hpp
@@ -432,11 +432,11 @@ private:
 
 	void CreateOrValidateTable(Connection &con, OtlpSignalType signal_type, const string &table_name);
 	void GetSignalColumns(OtlpSignalType signal_type, vector<LogicalType> &types, vector<string> &names);
-	//! Create a TEMP table matching `signal_type`'s schema on the writer connection and append
+	//! Create a TEMP table with columns `names`/`types` on the writer connection and append
 	//! `collection` into it. Returns the appended batch count. Shared staging step for the seal
 	//! paths that stage to a temp table before COPY (parquet export) or INSERT...SELECT (promotion).
-	idx_t StageCollectionToTempTable(OtlpSignalType signal_type, ColumnDataCollection &collection,
-	                                 const string &temp_table);
+	idx_t StageCollectionToTempTable(const vector<string> &names, const vector<LogicalType> &types,
+	                                 ColumnDataCollection &collection, const string &temp_table);
 
 private:
 	weak_ptr<DatabaseInstance> db_ptr;
@@ -446,6 +446,11 @@ private:
 	// Per-signal in-memory buffers. The vector is immutable after InitBuffers();
 	// each OtlpSignalBuffer carries its own mutex and mutable counters.
 	std::vector<unique_ptr<OtlpSignalBuffer>> signal_buffers;
+	//! Per-signal flag (EnsureTargetTables order == signal_buffers order, catalog mode only):
+	//! true when the persisted table has more columns than the base schema (e.g. a restart against
+	//! a previously promoted catalog). Such a table is sealed via a column-targeted INSERT so the
+	//! extra columns are NULL-filled. Empty in Parquet-export mode.
+	std::vector<bool> table_has_extra_columns;
 	//! Payload-byte admission counter for in-flight and unsealed accepted requests.
 	//! The single real byte counter: enforces max_buffered_bytes under concurrency and
 	//! drives the seal size trigger (seal_target_bytes).

--- a/src/include/otlp_sql_util.hpp
+++ b/src/include/otlp_sql_util.hpp
@@ -20,4 +20,15 @@ inline string QuoteIdentifier(const string &identifier) {
 	return "\"" + StringUtil::Replace(identifier, "\"", "\"\"") + "\"";
 }
 
+//! Build a quoted `[catalog.]schema.table` reference. An empty catalog means the connection's
+//! default catalog; schema is assumed non-empty (the live-ingest catalog modes always set one).
+inline string QualifiedTable(const string &catalog_name, const string &schema_name, const string &table_name) {
+	string qualified;
+	if (!catalog_name.empty()) {
+		qualified += QuoteIdentifier(catalog_name) + ".";
+	}
+	qualified += QuoteIdentifier(schema_name) + "." + QuoteIdentifier(table_name);
+	return qualified;
+}
+
 } // namespace duckdb

--- a/src/include/otlp_storage.hpp
+++ b/src/include/otlp_storage.hpp
@@ -60,6 +60,7 @@ public:
 		idx_t maintenance_failures_total;
 		int64_t last_maintenance_age_ms;
 		string maintenance_last_error;
+		idx_t promoted_columns_total;
 	};
 
 	vector<ServerSnapshot> ListServers();

--- a/src/otlp_column_promote.cpp
+++ b/src/otlp_column_promote.cpp
@@ -75,6 +75,7 @@ OtlpColumnPromoter::OtlpColumnPromoter(OtlpPromoteConfig config_p, string catalo
 	for (auto &c : columns) {
 		suffix += ", json_extract_string(" + QuoteIdentifier(c.source_column) + ", " + JsonPathLiteral(c.attr_key) +
 		          ") AS " + QuoteIdentifier(c.target_column);
+		target_list += ", " + QuoteIdentifier(c.target_column);
 	}
 }
 

--- a/src/otlp_column_promote.cpp
+++ b/src/otlp_column_promote.cpp
@@ -1,0 +1,142 @@
+#include "otlp_column_promote.hpp"
+
+#include "duckdb/main/connection.hpp"
+#include "duckdb/main/materialized_query_result.hpp"
+
+#include "otlp_sql_util.hpp"
+
+namespace duckdb {
+
+namespace {
+
+//! The six signal tables every server creates; resource_attributes/scope_attributes exist on all.
+const char *const SIGNAL_TABLES[] = {"otlp_logs",
+                                     "otlp_traces",
+                                     "otlp_metrics_gauge",
+                                     "otlp_metrics_sum",
+                                     "otlp_metrics_histogram",
+                                     "otlp_metrics_exp_histogram"};
+
+string QualifyTable(const string &catalog, const string &schema, const string &table) {
+	string out;
+	if (!catalog.empty()) {
+		out += QuoteIdentifier(catalog) + ".";
+	}
+	if (!schema.empty()) {
+		out += QuoteIdentifier(schema) + ".";
+	}
+	out += QuoteIdentifier(table);
+	return out;
+}
+
+void Exec(Connection &con, const string &sql) {
+	auto result = con.Query(sql);
+	if (!result || result->HasError()) {
+		throw IOException("%s", result ? result->GetError() : string("query failed"));
+	}
+}
+
+//! `attr_<sanitized>` body: lowercase-preserving, non-[A-Za-z0-9_] -> '_'.
+string Sanitize(const string &key) {
+	string out;
+	out.reserve(key.size());
+	for (char c : key) {
+		bool ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_';
+		out += ok ? c : '_';
+	}
+	return out;
+}
+
+//! JSONPath literal `'$."<key>"'`, escaping the inner quote/backslash so dotted keys stay one member.
+string JsonPathLiteral(const string &key) {
+	string escaped;
+	escaped.reserve(key.size());
+	for (char c : key) {
+		if (c == '\\' || c == '"') {
+			escaped += '\\';
+		}
+		escaped += c;
+	}
+	return SqlQuote("$.\"" + escaped + "\"");
+}
+
+} // namespace
+
+OtlpColumnPromoter::OtlpColumnPromoter(OtlpPromoteConfig config_p, string catalog_name_p, string schema_name_p,
+                                       std::function<void(const string &)> log_p)
+    : config(std::move(config_p)), catalog_name(std::move(catalog_name_p)), schema_name(std::move(schema_name_p)),
+      log(std::move(log_p)) {
+	auto add = [&](const string &source, const char *prefix, const string &key) {
+		if (key.empty()) {
+			return;
+		}
+		auto target = prefix + Sanitize(key);
+		// De-dupe (e.g. the same key listed twice, or two keys sanitizing alike).
+		for (auto &c : columns) {
+			if (c.target_column == target) {
+				return;
+			}
+		}
+		columns.push_back({source, key, target});
+	};
+	for (auto &key : config.resource_keys) {
+		add("resource_attributes", "resource_attr_", key);
+	}
+	for (auto &key : config.scope_keys) {
+		add("scope_attributes", "scope_attr_", key);
+	}
+	for (auto &c : columns) {
+		suffix += ", json_extract_string(" + QuoteIdentifier(c.source_column) + ", " + JsonPathLiteral(c.attr_key) +
+		          ") AS " + QuoteIdentifier(c.target_column);
+	}
+}
+
+void OtlpColumnPromoter::Disable(const string &reason) {
+	enabled = false;
+	suffix.clear();
+	promoted_count = 0;
+	if (log) {
+		log("attribute promotion disabled: " + reason);
+	}
+}
+
+void OtlpColumnPromoter::Initialize(Connection &con) {
+	if (columns.empty()) {
+		return;
+	}
+	// JSON functions back the extract; if unavailable we cannot promote.
+	try {
+		Exec(con, "LOAD json");
+	} catch (...) {
+		try {
+			Exec(con, "SELECT json_extract_string('{\"a\":1}', '$.\"a\"')");
+		} catch (std::exception &ex) {
+			Disable(string("json extension unavailable: ") + ex.what());
+			return;
+		}
+	}
+	// Add every promoted column on every signal table (idempotent). A fixed config means the first
+	// ALTER failure indicates the catalog cannot add columns (e.g. an Iceberg REST catalog without
+	// write support), so disable rather than retry per column/table.
+	for (auto *table : SIGNAL_TABLES) {
+		auto qualified = QualifyTable(catalog_name, schema_name, table);
+		for (auto &c : columns) {
+			try {
+				Exec(con, "ALTER TABLE " + qualified + " ADD COLUMN IF NOT EXISTS " + QuoteIdentifier(c.target_column) +
+				              " VARCHAR");
+			} catch (std::exception &ex) {
+				Disable(StringUtil::Format("ALTER ADD COLUMN on %s failed (catalog may not support it): %s", table,
+				                           ex.what()));
+				return;
+			}
+		}
+	}
+	enabled = true;
+	promoted_count = columns.size();
+	if (log) {
+		log(StringUtil::Format("attribute promotion enabled: %llu column(s) per signal",
+		                       static_cast<uint64_t>(columns.size())));
+	}
+}
+
+} // namespace duckdb

--- a/src/otlp_column_promote.cpp
+++ b/src/otlp_column_promote.cpp
@@ -17,18 +17,6 @@ const char *const SIGNAL_TABLES[] = {"otlp_logs",
                                      "otlp_metrics_histogram",
                                      "otlp_metrics_exp_histogram"};
 
-string QualifyTable(const string &catalog, const string &schema, const string &table) {
-	string out;
-	if (!catalog.empty()) {
-		out += QuoteIdentifier(catalog) + ".";
-	}
-	if (!schema.empty()) {
-		out += QuoteIdentifier(schema) + ".";
-	}
-	out += QuoteIdentifier(table);
-	return out;
-}
-
 void Exec(Connection &con, const string &sql) {
 	auto result = con.Query(sql);
 	if (!result || result->HasError()) {
@@ -64,8 +52,7 @@ string JsonPathLiteral(const string &key) {
 
 OtlpColumnPromoter::OtlpColumnPromoter(OtlpPromoteConfig config_p, string catalog_name_p, string schema_name_p,
                                        std::function<void(const string &)> log_p)
-    : config(std::move(config_p)), catalog_name(std::move(catalog_name_p)), schema_name(std::move(schema_name_p)),
-      log(std::move(log_p)) {
+    : catalog_name(std::move(catalog_name_p)), schema_name(std::move(schema_name_p)), log(std::move(log_p)) {
 	auto add = [&](const string &source, const char *prefix, const string &key) {
 		if (key.empty()) {
 			return;
@@ -79,10 +66,10 @@ OtlpColumnPromoter::OtlpColumnPromoter(OtlpPromoteConfig config_p, string catalo
 		}
 		columns.push_back({source, key, target});
 	};
-	for (auto &key : config.resource_keys) {
+	for (auto &key : config_p.resource_keys) {
 		add("resource_attributes", "resource_attr_", key);
 	}
-	for (auto &key : config.scope_keys) {
+	for (auto &key : config_p.scope_keys) {
 		add("scope_attributes", "scope_attr_", key);
 	}
 	for (auto &c : columns) {
@@ -92,9 +79,9 @@ OtlpColumnPromoter::OtlpColumnPromoter(OtlpPromoteConfig config_p, string catalo
 }
 
 void OtlpColumnPromoter::Disable(const string &reason) {
+	// ProjectionSuffix()/PromotedColumnsTotal() are only consulted when Enabled(), so clearing
+	// `enabled` is enough — no need to also wipe suffix/columns.
 	enabled = false;
-	suffix.clear();
-	promoted_count = 0;
 	if (log) {
 		log("attribute promotion disabled: " + reason);
 	}
@@ -119,7 +106,7 @@ void OtlpColumnPromoter::Initialize(Connection &con) {
 	// ALTER failure indicates the catalog cannot add columns (e.g. an Iceberg REST catalog without
 	// write support), so disable rather than retry per column/table.
 	for (auto *table : SIGNAL_TABLES) {
-		auto qualified = QualifyTable(catalog_name, schema_name, table);
+		auto qualified = QualifiedTable(catalog_name, schema_name, table);
 		for (auto &c : columns) {
 			try {
 				Exec(con, "ALTER TABLE " + qualified + " ADD COLUMN IF NOT EXISTS " + QuoteIdentifier(c.target_column) +
@@ -132,7 +119,6 @@ void OtlpColumnPromoter::Initialize(Connection &con) {
 		}
 	}
 	enabled = true;
-	promoted_count = columns.size();
 	if (log) {
 		log(StringUtil::Format("attribute promotion enabled: %llu column(s) per signal",
 		                       static_cast<uint64_t>(columns.size())));

--- a/src/otlp_server.cpp
+++ b/src/otlp_server.cpp
@@ -91,15 +91,6 @@ static bool TimingSafeEqual(const string &a, const string &b) {
 	return diff == 0;
 }
 
-static string QualifiedTable(const string &catalog_name, const string &schema_name, const string &table_name) {
-	string qualified;
-	if (!catalog_name.empty()) {
-		qualified += QuoteIdentifier(catalog_name) + ".";
-	}
-	qualified += QuoteIdentifier(schema_name) + "." + QuoteIdentifier(table_name);
-	return qualified;
-}
-
 static string ExportRootForTable(const string &root, const string &table_name) {
 	if (root.empty()) {
 		return "";
@@ -951,6 +942,21 @@ OtlpIngestResult OtlpServer::SealOnce(bool allow_maintenance) {
 	return SealCatalog(plan, seal_started_unix_ms, allow_maintenance, *db);
 }
 
+idx_t OtlpServer::StageCollectionToTempTable(OtlpSignalType signal_type, ColumnDataCollection &collection,
+                                             const string &temp_table) {
+	vector<LogicalType> staging_types;
+	vector<string> staging_names;
+	GetSignalColumns(signal_type, staging_types, staging_names);
+	string ddl = "CREATE TEMP TABLE " + QuoteIdentifier(temp_table) + " (";
+	for (idx_t c = 0; c < staging_names.size(); c++) {
+		ddl +=
+		    (c > 0 ? string(", ") : string()) + QuoteIdentifier(staging_names[c]) + " " + staging_types[c].ToString();
+	}
+	ddl += ")";
+	RunSQL(*writer_con, ddl);
+	return AppendCollectionToTable(*writer_con, collection, string(), string(), temp_table);
+}
+
 OtlpIngestResult OtlpServer::SealParquet(SealingPlan &plan, int64_t seal_started_unix_ms) {
 	int64_t append_duration_ms = 0;
 	int64_t commit_duration_ms = 0;
@@ -984,21 +990,9 @@ OtlpIngestResult OtlpServer::SealParquet(SealingPlan &plan, int64_t seal_started
 			    StringUtil::Format("__otlp_seal_%s_%llu_%llu_%llu", buf.table_name, static_cast<uint64_t>(seal_id),
 			                       static_cast<uint64_t>(seal_attempt_id), static_cast<uint64_t>(i));
 			try {
-				// Stage this seal's rows in a TEMP table whose schema is derived from the
-				// signal definition (not a persistent destination), then COPY only those
-				// rows to the partitioned dataset.
-				vector<LogicalType> staging_types;
-				vector<string> staging_names;
-				GetSignalColumns(buf.signal_type, staging_types, staging_names);
-				string ddl = "CREATE TEMP TABLE " + QuoteIdentifier(staging) + " (";
-				for (idx_t c = 0; c < staging_names.size(); c++) {
-					ddl += (c > 0 ? string(", ") : string()) + QuoteIdentifier(staging_names[c]) + " " +
-					       staging_types[c].ToString();
-				}
-				ddl += ")";
-				RunSQL(*writer_con, ddl);
-				result.batches +=
-				    AppendCollectionToTable(*writer_con, *sealing[i].collection, string(), string(), staging);
+				// Stage this seal's rows in a TEMP table (schema from the signal definition), then
+				// COPY only those rows to the partitioned dataset.
+				result.batches += StageCollectionToTempTable(buf.signal_type, *sealing[i].collection, staging);
 #ifdef DUCKDB_OTLP_ENABLE_TEST_SEAM
 				// Test-only fault injection: simulate a per-signal COPY failure so the harness can
 				// assert the at-least-once partial-export + proportional-admission re-buffer path.
@@ -1130,17 +1124,7 @@ OtlpIngestResult OtlpServer::SealCatalog(SealingPlan &plan, int64_t seal_started
 			auto temp = StringUtil::Format("__otlp_promote_%s_%llu_%llu", buf.table_name,
 			                               static_cast<uint64_t>(seal_id), static_cast<uint64_t>(i));
 			try {
-				vector<LogicalType> staging_types;
-				vector<string> staging_names;
-				GetSignalColumns(buf.signal_type, staging_types, staging_names);
-				string ddl = "CREATE TEMP TABLE " + QuoteIdentifier(temp) + " (";
-				for (idx_t c = 0; c < staging_names.size(); c++) {
-					ddl += (c > 0 ? string(", ") : string()) + QuoteIdentifier(staging_names[c]) + " " +
-					       staging_types[c].ToString();
-				}
-				ddl += ")";
-				RunSQL(*writer_con, ddl);
-				AppendCollectionToTable(*writer_con, *sealing[i].collection, string(), string(), temp);
+				StageCollectionToTempTable(buf.signal_type, *sealing[i].collection, temp);
 				temp_tables[i] = temp;
 			} catch (std::exception &ex) {
 				try {

--- a/src/otlp_server.cpp
+++ b/src/otlp_server.cpp
@@ -501,8 +501,12 @@ void OtlpServer::CreateOrValidateTable(Connection &con, OtlpSignalType signal_ty
 		throw IOException("Target table %s is not available: %s", qualified,
 		                  result ? result->GetError() : "query failed");
 	}
-	if (result->names.size() != expected_names.size()) {
-		throw InvalidInputException("Target table %s has %llu columns, expected %llu", qualified,
+	// The signal's base columns must be present as a leading prefix (name + type, in order). Extra
+	// trailing columns are allowed: attribute promotion adds resource_attr_*/scope_attr_* columns
+	// via ALTER, and a restart against an already-promoted catalog must validate cleanly. The seal
+	// path targets columns by name so those extras are NULL-filled when not being populated.
+	if (result->names.size() < expected_names.size()) {
+		throw InvalidInputException("Target table %s has %llu columns, expected at least %llu", qualified,
 		                            static_cast<uint64_t>(result->names.size()),
 		                            static_cast<uint64_t>(expected_names.size()));
 	}
@@ -516,6 +520,9 @@ void OtlpServer::CreateOrValidateTable(Connection &con, OtlpSignalType signal_ty
 			                            expected_names[i], result->types[i].ToString(), expected_types[i].ToString());
 		}
 	}
+	// Recorded in EnsureTargetTables order (== signal_buffers order) so the seal can pick the
+	// column-targeting write path for a table that carries extra (promoted) columns.
+	table_has_extra_columns.push_back(result->names.size() > expected_names.size());
 }
 
 OtlpIngestResult OtlpServer::Ingest(OtlpRequestKind kind, const string &content_type, const string &content_encoding,
@@ -942,15 +949,11 @@ OtlpIngestResult OtlpServer::SealOnce(bool allow_maintenance) {
 	return SealCatalog(plan, seal_started_unix_ms, allow_maintenance, *db);
 }
 
-idx_t OtlpServer::StageCollectionToTempTable(OtlpSignalType signal_type, ColumnDataCollection &collection,
-                                             const string &temp_table) {
-	vector<LogicalType> staging_types;
-	vector<string> staging_names;
-	GetSignalColumns(signal_type, staging_types, staging_names);
+idx_t OtlpServer::StageCollectionToTempTable(const vector<string> &names, const vector<LogicalType> &types,
+                                             ColumnDataCollection &collection, const string &temp_table) {
 	string ddl = "CREATE TEMP TABLE " + QuoteIdentifier(temp_table) + " (";
-	for (idx_t c = 0; c < staging_names.size(); c++) {
-		ddl +=
-		    (c > 0 ? string(", ") : string()) + QuoteIdentifier(staging_names[c]) + " " + staging_types[c].ToString();
+	for (idx_t c = 0; c < names.size(); c++) {
+		ddl += (c > 0 ? string(", ") : string()) + QuoteIdentifier(names[c]) + " " + types[c].ToString();
 	}
 	ddl += ")";
 	RunSQL(*writer_con, ddl);
@@ -992,7 +995,11 @@ OtlpIngestResult OtlpServer::SealParquet(SealingPlan &plan, int64_t seal_started
 			try {
 				// Stage this seal's rows in a TEMP table (schema from the signal definition), then
 				// COPY only those rows to the partitioned dataset.
-				result.batches += StageCollectionToTempTable(buf.signal_type, *sealing[i].collection, staging);
+				vector<LogicalType> staging_types;
+				vector<string> staging_names;
+				GetSignalColumns(buf.signal_type, staging_types, staging_names);
+				result.batches +=
+				    StageCollectionToTempTable(staging_names, staging_types, *sealing[i].collection, staging);
 #ifdef DUCKDB_OTLP_ENABLE_TEST_SEAM
 				// Test-only fault injection: simulate a per-signal COPY failure so the harness can
 				// assert the at-least-once partial-export + proportional-admission re-buffer path.
@@ -1107,35 +1114,51 @@ OtlpIngestResult OtlpServer::SealCatalog(SealingPlan &plan, int64_t seal_started
 	auto &sealing = plan.signals;
 	OtlpIngestResult result;
 
-	// Attribute promotion: when enabled, each signal's rows go through a TEMP table so the seal can
-	// INSERT...SELECT them with the promoted attribute columns extracted from the JSON blob. Promoted
-	// columns were ALTERed once at startup, so the schema is stable here — no per-seal DDL. The temp
-	// tables are staged OUTSIDE the data transaction; the transaction below only does the INSERTs.
-	// Best-effort: a staging failure drops that signal back to the fast Appender path.
+	// Attribute promotion / schema evolution: a signal whose target table is wider than the base
+	// schema — because promotion is enabled, or because a prior run promoted columns into a persisted
+	// catalog — is sealed via a column-targeted INSERT...SELECT from a TEMP table, so the extra
+	// columns are populated (promotion) or NULL-filled (otherwise). Tables that are exactly the base
+	// schema keep the fast direct Appender path. Temp tables are staged OUTSIDE the data transaction;
+	// the transaction below only runs the INSERTs. Best-effort: a staging failure drops that signal
+	// back to the Appender path.
 	const bool promote = promoter && promoter->Enabled();
 	std::vector<string> temp_tables(signal_buffers.size());
-	if (promote) {
-		auto seal_id = seals_total.load() + 1;
-		for (idx_t i = 0; i < signal_buffers.size(); i++) {
-			if (sealing[i].rows == 0) {
-				continue;
+	std::vector<string> insert_columns(signal_buffers.size());
+	auto seal_id = seals_total.load() + 1;
+	for (idx_t i = 0; i < signal_buffers.size(); i++) {
+		if (sealing[i].rows == 0) {
+			continue;
+		}
+		bool has_extra = i < table_has_extra_columns.size() && table_has_extra_columns[i];
+		if (!promote && !has_extra) {
+			continue; // base-width table, no promotion: fast Appender path below
+		}
+		auto &buf = *signal_buffers[i];
+		auto temp = StringUtil::Format("__otlp_promote_%s_%llu_%llu", buf.table_name, static_cast<uint64_t>(seal_id),
+		                               static_cast<uint64_t>(i));
+		try {
+			vector<LogicalType> staging_types;
+			vector<string> staging_names;
+			GetSignalColumns(buf.signal_type, staging_types, staging_names);
+			StageCollectionToTempTable(staging_names, staging_types, *sealing[i].collection, temp);
+			string cols;
+			for (idx_t c = 0; c < staging_names.size(); c++) {
+				cols += (c > 0 ? string(", ") : string()) + QuoteIdentifier(staging_names[c]);
 			}
-			auto &buf = *signal_buffers[i];
-			auto temp = StringUtil::Format("__otlp_promote_%s_%llu_%llu", buf.table_name,
-			                               static_cast<uint64_t>(seal_id), static_cast<uint64_t>(i));
+			if (promote) {
+				cols += promoter->TargetColumnList();
+			}
+			temp_tables[i] = temp;
+			insert_columns[i] = cols;
+		} catch (std::exception &ex) {
 			try {
-				StageCollectionToTempTable(buf.signal_type, *sealing[i].collection, temp);
-				temp_tables[i] = temp;
-			} catch (std::exception &ex) {
-				try {
-					DropTableIfExists(*writer_con, temp);
-				} catch (...) {
-				}
-				temp_tables[i].clear();
-				LogServerEvent(
-				    StringUtil::Format("attribute promotion: staging failed for %s: %s", buf.table_name, ex.what()),
-				    LogLevel::LOG_WARNING);
+				DropTableIfExists(*writer_con, temp);
+			} catch (...) {
 			}
+			temp_tables[i].clear();
+			LogServerEvent(
+			    StringUtil::Format("attribute promotion: staging failed for %s: %s", buf.table_name, ex.what()),
+			    LogLevel::LOG_WARNING);
 		}
 	}
 	auto drop_temp_tables = [&]() {
@@ -1159,12 +1182,13 @@ OtlpIngestResult OtlpServer::SealCatalog(SealingPlan &plan, int64_t seal_started
 			}
 			auto &buf = *signal_buffers[i];
 			if (!temp_tables[i].empty()) {
-				// Promoted path: copy staged rows plus the json_extract'd promoted columns. Positional
-				// INSERT is safe — the target's base columns match GetSignalColumns order, and promoted
-				// columns are appended by ALTER in the same order ProjectionSuffix emits them.
+				// Column-targeted INSERT: name every base column (+ promoted columns when enabled) so
+				// values map by name, not position, and any other columns the table carries are
+				// NULL-filled.
 				auto target = QualifiedTable(config.catalog_name, config.schema_name, buf.table_name);
-				RunSQL(*writer_con, "INSERT INTO " + target + " SELECT *" + promoter->ProjectionSuffix() + " FROM " +
-				                        QuoteIdentifier(temp_tables[i]));
+				string select_list = string("*") + (promote ? promoter->ProjectionSuffix() : string());
+				RunSQL(*writer_con, "INSERT INTO " + target + " (" + insert_columns[i] + ") SELECT " + select_list +
+				                        " FROM " + QuoteIdentifier(temp_tables[i]));
 				result.batches += 1;
 			} else {
 				result.batches += AppendCollectionToTable(*writer_con, *sealing[i].collection, config.catalog_name,

--- a/src/otlp_server.cpp
+++ b/src/otlp_server.cpp
@@ -13,6 +13,7 @@
 #include "duckdb/main/query_result.hpp"
 
 #include "otlp_arrow.hpp"
+#include "otlp_column_promote.hpp"
 #include "otlp_log.hpp"
 #include "otlp_server_internal.hpp"
 #include "otlp_sql_util.hpp"
@@ -1112,6 +1113,59 @@ OtlpIngestResult OtlpServer::SealCatalog(SealingPlan &plan, int64_t seal_started
 	auto &sealing = plan.signals;
 	OtlpIngestResult result;
 
+	// Attribute promotion: when enabled, each signal's rows go through a TEMP table so the seal can
+	// INSERT...SELECT them with the promoted attribute columns extracted from the JSON blob. Promoted
+	// columns were ALTERed once at startup, so the schema is stable here — no per-seal DDL. The temp
+	// tables are staged OUTSIDE the data transaction; the transaction below only does the INSERTs.
+	// Best-effort: a staging failure drops that signal back to the fast Appender path.
+	const bool promote = promoter && promoter->Enabled();
+	std::vector<string> temp_tables(signal_buffers.size());
+	if (promote) {
+		auto seal_id = seals_total.load() + 1;
+		for (idx_t i = 0; i < signal_buffers.size(); i++) {
+			if (sealing[i].rows == 0) {
+				continue;
+			}
+			auto &buf = *signal_buffers[i];
+			auto temp = StringUtil::Format("__otlp_promote_%s_%llu_%llu", buf.table_name,
+			                               static_cast<uint64_t>(seal_id), static_cast<uint64_t>(i));
+			try {
+				vector<LogicalType> staging_types;
+				vector<string> staging_names;
+				GetSignalColumns(buf.signal_type, staging_types, staging_names);
+				string ddl = "CREATE TEMP TABLE " + QuoteIdentifier(temp) + " (";
+				for (idx_t c = 0; c < staging_names.size(); c++) {
+					ddl += (c > 0 ? string(", ") : string()) + QuoteIdentifier(staging_names[c]) + " " +
+					       staging_types[c].ToString();
+				}
+				ddl += ")";
+				RunSQL(*writer_con, ddl);
+				AppendCollectionToTable(*writer_con, *sealing[i].collection, string(), string(), temp);
+				temp_tables[i] = temp;
+			} catch (std::exception &ex) {
+				try {
+					DropTableIfExists(*writer_con, temp);
+				} catch (...) {
+				}
+				temp_tables[i].clear();
+				LogServerEvent(
+				    StringUtil::Format("attribute promotion: staging failed for %s: %s", buf.table_name, ex.what()),
+				    LogLevel::LOG_WARNING);
+			}
+		}
+	}
+	auto drop_temp_tables = [&]() {
+		for (auto &temp : temp_tables) {
+			if (temp.empty()) {
+				continue;
+			}
+			try {
+				DropTableIfExists(*writer_con, temp);
+			} catch (...) {
+			}
+		}
+	};
+
 	try {
 		RunSQL(*writer_con, "BEGIN TRANSACTION");
 		auto append_started = std::chrono::steady_clock::now();
@@ -1120,8 +1174,18 @@ OtlpIngestResult OtlpServer::SealCatalog(SealingPlan &plan, int64_t seal_started
 				continue;
 			}
 			auto &buf = *signal_buffers[i];
-			result.batches += AppendCollectionToTable(*writer_con, *sealing[i].collection, config.catalog_name,
-			                                          config.schema_name, buf.table_name);
+			if (!temp_tables[i].empty()) {
+				// Promoted path: copy staged rows plus the json_extract'd promoted columns. Positional
+				// INSERT is safe — the target's base columns match GetSignalColumns order, and promoted
+				// columns are appended by ALTER in the same order ProjectionSuffix emits them.
+				auto target = QualifiedTable(config.catalog_name, config.schema_name, buf.table_name);
+				RunSQL(*writer_con, "INSERT INTO " + target + " SELECT *" + promoter->ProjectionSuffix() + " FROM " +
+				                        QuoteIdentifier(temp_tables[i]));
+				result.batches += 1;
+			} else {
+				result.batches += AppendCollectionToTable(*writer_con, *sealing[i].collection, config.catalog_name,
+				                                          config.schema_name, buf.table_name);
+			}
 			result.rows += sealing[i].rows;
 		}
 		append_duration_ms =
@@ -1180,11 +1244,13 @@ OtlpIngestResult OtlpServer::SealCatalog(SealingPlan &plan, int64_t seal_started
 			std::vector<bool> restore(signal_buffers.size(), true);
 			RestoreUnsealed(plan, restore);
 		}
+		drop_temp_tables();
 		LogServerEvent(StringUtil::Format("seal failed: %s", msg), LogLevel::LOG_WARNING);
 		RecordSealOutcome(false, 0, 0, seal_started_unix_ms, append_duration_ms, commit_duration_ms, msg);
 		throw;
 	}
 
+	drop_temp_tables();
 	ReleaseAdmission(sealed_admission_bytes);
 	LogServerEvent(StringUtil::Format("seal: catalog=%s rows=%llu batches=%llu", config.catalog_name,
 	                                  static_cast<uint64_t>(result.rows), static_cast<uint64_t>(result.batches)));

--- a/src/otlp_server_http.cpp
+++ b/src/otlp_server_http.cpp
@@ -94,6 +94,13 @@ OtlpServer::OtlpServer(ClientContext &context, const OtlpUri &uri_p, const OtlpS
 	// size + snapshot/file retention) before the sealer can fire. Best-effort; no-op for the
 	// default/non-DuckLake catalogs.
 	ConfigureCatalogMaintenanceOptions();
+	// Attribute promotion (opt-in, catalog mode only): add the operator-specified resource/scope
+	// attribute columns once, before the sealer fires. Parquet-export mode has no table to ALTER.
+	if (config.promote.Enabled() && config.parquet_export_path.empty()) {
+		promoter = make_uniq<OtlpColumnPromoter>(config.promote, config.catalog_name, config.schema_name,
+		                                         [this](const string &msg) { LogServerEvent(msg); });
+		promoter->Initialize(*writer_con);
+	}
 	StartSealer();
 
 	if (config.transport == OtlpTransport::GRPC) {

--- a/src/otlp_start_stop.cpp
+++ b/src/otlp_start_stop.cpp
@@ -181,6 +181,23 @@ static unique_ptr<FunctionData> OtlpServeBindImpl(ClientContext &context, TableF
 			throw InvalidInputException("maintenance_retention_ms must be greater than zero");
 		}
 	}
+	// Attribute promotion: comma-separated lists of resource / scope attribute keys to promote into
+	// first-class columns at ingest.
+	auto parse_attr_keys = [&](const char *param, vector<string> &out) {
+		auto it = input.named_parameters.find(param);
+		if (it == input.named_parameters.end()) {
+			return;
+		}
+		for (auto &part : StringUtil::Split(it->second.GetValue<string>(), ',')) {
+			auto key = part;
+			StringUtil::Trim(key);
+			if (!key.empty()) {
+				out.push_back(key);
+			}
+		}
+	};
+	parse_attr_keys("promote_resource_attributes", bind_data->config.promote.resource_keys);
+	parse_attr_keys("promote_scope_attributes", bind_data->config.promote.scope_keys);
 
 	names.emplace_back("listen_uri");
 	return_types.emplace_back(OtlpVarcharType());
@@ -267,6 +284,9 @@ static TableFunctionSet BuildServeFunctionSet(const string &name, table_function
 	fun.named_parameters["seal_max_age_ms"] = OtlpBigIntType();
 	fun.named_parameters["target_file_size"] = OtlpUBigIntType();
 	fun.named_parameters["maintenance_retention_ms"] = OtlpBigIntType();
+	// Attribute promotion: comma-separated resource / scope attribute keys to promote.
+	fun.named_parameters["promote_resource_attributes"] = OtlpVarcharType();
+	fun.named_parameters["promote_scope_attributes"] = OtlpVarcharType();
 	set.AddFunction(fun);
 	fun.arguments.clear();
 	set.AddFunction(fun);
@@ -386,6 +406,8 @@ static unique_ptr<FunctionData> OtlpServerListBind(ClientContext &context, Table
 	// Appended (not inserted next to buffered_rows) so existing column positions are unchanged.
 	names.emplace_back("buffered_bytes");
 	return_types.emplace_back(OtlpUBigIntType());
+	names.emplace_back("promoted_columns_total");
+	return_types.emplace_back(OtlpUBigIntType());
 	return make_uniq<OtlpServerListFunctionData>();
 }
 
@@ -432,6 +454,7 @@ static void OtlpServerList(ClientContext &context, TableFunctionInput &data_p, D
 		output.SetValue(
 		    24, row, s.maintenance_last_error.empty() ? Value(LogicalType::VARCHAR) : Value(s.maintenance_last_error));
 		output.SetValue(25, row, Value::UBIGINT(s.buffered_bytes));
+		output.SetValue(26, row, Value::UBIGINT(s.promoted_columns_total));
 		row++;
 		bind_data.offset++;
 	}

--- a/src/otlp_storage.cpp
+++ b/src/otlp_storage.cpp
@@ -196,6 +196,7 @@ vector<OtlpStorageExtensionInfo::ServerSnapshot> OtlpStorageExtensionInfo::ListS
 		snap.maintenance_failures_total = server.MaintenanceFailuresTotal();
 		snap.last_maintenance_age_ms = server.LastMaintenanceAgeMs();
 		snap.maintenance_last_error = server.MaintenanceLastError();
+		snap.promoted_columns_total = server.PromotedColumnsTotal();
 		result.push_back(std::move(snap));
 	}
 	// servers is an unordered_map; sort for deterministic output order.

--- a/src/server/server_config.cpp
+++ b/src/server/server_config.cpp
@@ -663,6 +663,8 @@ ServerConfig ServerConfig::FromEnv() {
 	    ParsePositiveUInt64Env("DUCKDB_OTLP_TARGET_FILE_SIZE", otlp_limits::DEFAULT_TARGET_FILE_SIZE);
 	config.maintenance_retention_ms =
 	    ParsePositiveInt64Env("DUCKDB_OTLP_MAINTENANCE_RETENTION_MS", otlp_limits::DEFAULT_MAINTENANCE_RETENTION_MS);
+	config.promote_resource_attributes = Env("DUCKDB_OTLP_PROMOTE_RESOURCE_ATTRIBUTES", "");
+	config.promote_scope_attributes = Env("DUCKDB_OTLP_PROMOTE_SCOPE_ATTRIBUTES", "");
 
 	auto quack_token_var = FirstEnv({"DUCKDB_QUACK_TOKEN", "QUACK_AUTH_TOKEN"});
 	if (config.quack_enabled && quack_token_var.empty()) {
@@ -704,6 +706,15 @@ string ServerConfig::StartOtlpSql() const {
 	auto export_sql = parquet_export_path.empty()
 	                      ? string("")
 	                      : StringUtil::Format(",\n    parquet_export_path := %s", SqlQuote(parquet_export_path));
+	// Attribute promotion params, emitted only when set so the common path is unchanged.
+	string promote_sql;
+	if (!promote_resource_attributes.empty()) {
+		promote_sql +=
+		    StringUtil::Format(",\n    promote_resource_attributes := %s", SqlQuote(promote_resource_attributes));
+	}
+	if (!promote_scope_attributes.empty()) {
+		promote_sql += StringUtil::Format(",\n    promote_scope_attributes := %s", SqlQuote(promote_scope_attributes));
+	}
 	auto schema_target =
 	    catalog.empty() ? QuoteIdentifier(schema) : QuoteIdentifier(catalog) + "." + QuoteIdentifier(schema);
 	// Pick the serve function by scheme so listen URIs are never mixed across them:
@@ -722,11 +733,11 @@ FROM %s(
     catalog := %s,
     schema := %s,
     token := getvariable('duckdb_otlp_effective_token'),
-    allow_other_hostname := true%s%s%s
+    allow_other_hostname := true%s%s%s%s
 );
 )SQL",
 	                          schema_target, serve_fn, SqlQuote(listen_uri), SqlQuote(catalog), SqlQuote(schema),
-	                          thread_sql, limits_sql, export_sql);
+	                          thread_sql, limits_sql, export_sql, promote_sql);
 }
 
 string ServerConfig::StartQuackSql() const {

--- a/src/server/server_config.hpp
+++ b/src/server/server_config.hpp
@@ -39,6 +39,10 @@ struct ServerConfig {
 	int64_t seal_max_age_ms = 5000;
 	uint64_t target_file_size = 256ULL * 1024ULL * 1024ULL;
 	int64_t maintenance_retention_ms = 15LL * 60LL * 1000LL;
+	//! Attribute promotion (opt-in): comma-separated resource / scope attribute keys to promote into
+	//! first-class columns at ingest. Emitted into the otlp_serve() call when non-empty.
+	duckdb::string promote_resource_attributes;
+	duckdb::string promote_scope_attributes;
 
 	duckdb::string mode_setup_sql;
 	std::vector<duckdb::string> mode_extensions;

--- a/test/manual/otlp_serve_promote.py
+++ b/test/manual/otlp_serve_promote.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.9"
+# dependencies = [
+#   "duckdb==1.5.4",
+# ]
+# ///
+"""Manual HTTP hot-path coverage for attribute promotion.
+
+SQLLogicTest cannot drive HTTP ingest, so the promotion path (extract operator-named
+resource/scope attribute keys out of the JSON blob into first-class columns at seal)
+is verified here against the default in-memory catalog and, optionally, DuckLake:
+
+  * promote_resource_attributes / promote_scope_attributes create attr columns at startup
+  * those columns are populated from the blob at ingest
+  * COALESCE(attr_x, json_extract_string(blob,'$."x"')) reconstructs (blob kept)
+  * otlp_server_list().promoted_columns_total reflects the count
+
+Run:
+    uv run --script test/manual/otlp_serve_promote.py
+    OTLP_DUCKLAKE_DIR=/tmp/otlp_promote_lake uv run --script test/manual/otlp_serve_promote.py
+"""
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+import duckdb
+
+EXTENSION = os.environ.get("OTLP_EXTENSION", "build/release/extension/otlp/otlp.duckdb_extension")
+BASE_PORT = int(os.environ.get("OTLP_PORT", "4347"))
+DUCKLAKE_DIR = os.environ.get("OTLP_DUCKLAKE_DIR", "")
+TOKEN = "manual-promote-token-0123456789"
+
+# One log record carrying a resource attribute (host.name) and a scope attribute (scope.team).
+PAYLOAD = json.dumps(
+    {
+        "resourceLogs": [
+            {
+                "resource": {
+                    "attributes": [
+                        {"key": "service.name", "value": {"stringValue": "svc"}},
+                        {"key": "host.name", "value": {"stringValue": "host-1"}},
+                    ]
+                },
+                "scopeLogs": [
+                    {
+                        "scope": {
+                            "name": "s",
+                            "attributes": [{"key": "scope.team", "value": {"stringValue": "observability"}}],
+                        },
+                        "logRecords": [
+                            {
+                                "timeUnixNano": "1700000000000000000",
+                                "severityText": "INFO",
+                                "body": {"stringValue": "hello"},
+                                "attributes": [{"key": "http.route", "value": {"stringValue": "/x"}}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+    }
+).encode()
+
+
+def quote_ident(name):
+    return '"' + name.replace('"', '""') + '"'
+
+
+def connect():
+    con = duckdb.connect(config={"allow_unsigned_extensions": "true"})
+    con.execute(f"LOAD '{EXTENSION}'")
+    catalog = ""
+    table_prefix = ""
+    if DUCKLAKE_DIR:
+        catalog = "lake_promote"
+        os.makedirs(DUCKLAKE_DIR, exist_ok=True)
+        con.execute("LOAD ducklake")
+        con.execute(
+            f"ATTACH 'ducklake:{DUCKLAKE_DIR}/meta.ducklake' AS {quote_ident(catalog)} "
+            f"(DATA_PATH '{DUCKLAKE_DIR}/data/')"
+        )
+        table_prefix = f"{quote_ident(catalog)}.main."
+    return con, catalog, table_prefix
+
+
+def start_server(con, port, catalog="", **options):
+    sql = "SELECT listen_url FROM otlp_serve(?, token := ?"
+    params = [f"otlp:127.0.0.1:{port}", TOKEN]
+    if catalog:
+        sql += ", catalog := ?"
+        params.append(catalog)
+    for name, value in options.items():
+        sql += f", {name} := ?"
+        params.append(value)
+    sql += ")"
+    return con.execute(sql, params).fetchone()[0]
+
+
+def post(url, body):
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json", "Authorization": f"Bearer {TOKEN}"},
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, resp.read().decode()
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.read().decode() if exc.fp else ""
+    except Exception as exc:
+        return 0, str(exc)
+
+
+def column_names(con, table_prefix, table):
+    return [r[0] for r in con.execute(f"SELECT * FROM {table_prefix}{table} LIMIT 0").description]
+
+
+def require(failures, condition, message):
+    if not condition:
+        failures.append(message)
+    print(("  ok " if condition else "  FAIL ") + message)
+
+
+def run(failures):
+    port = BASE_PORT
+    con, catalog, table_prefix = connect()
+    base_url = start_server(
+        con,
+        port,
+        catalog=catalog,
+        promote_resource_attributes="host.name",
+        promote_scope_attributes="scope.team",
+    )
+    print(f"[promote] {base_url} catalog={catalog or '<default>'}")
+
+    # Columns exist before any data (added at server start).
+    cols = column_names(con, table_prefix, "otlp_logs")
+    require(failures, "resource_attr_host_name" in cols, f"resource_attr_host_name present at startup (cols={cols})")
+    require(failures, "scope_attr_scope_team" in cols, "scope_attr_scope_team present at startup")
+
+    accepted = 0
+    for _ in range(3):
+        status, text = post(base_url + "/v1/logs", PAYLOAD)
+        require(failures, status == 202, f"ingest expected 202, got {status}: {text}")
+        if status == 202:
+            accepted += int(json.loads(text)["rows"])
+    con.execute("SELECT status FROM otlp_flush(?)", [f"otlp:127.0.0.1:{port}"]).fetchone()
+
+    total = con.execute(f"SELECT count(*) FROM {table_prefix}otlp_logs").fetchone()[0]
+    require(failures, total == accepted, f"otlp_logs rows {total} == accepted {accepted}")
+
+    res_ok = con.execute(
+        f"SELECT count(*) FROM {table_prefix}otlp_logs WHERE resource_attr_host_name = 'host-1'"
+    ).fetchone()[0]
+    require(failures, res_ok == total, f"resource attr promoted+populated ({res_ok}/{total})")
+
+    scope_ok = con.execute(
+        f"SELECT count(*) FROM {table_prefix}otlp_logs WHERE scope_attr_scope_team = 'observability'"
+    ).fetchone()[0]
+    require(failures, scope_ok == total, f"scope attr promoted+populated ({scope_ok}/{total})")
+
+    mismatches = con.execute(
+        f"SELECT count(*) FROM {table_prefix}otlp_logs "
+        f"WHERE resource_attr_host_name IS DISTINCT FROM "
+        f"json_extract_string(resource_attributes, '$.\"host.name\"')"
+    ).fetchone()[0]
+    require(failures, mismatches == 0, f"promoted column reconstructs from blob (mismatches={mismatches})")
+
+    promoted_total = con.execute(
+        "SELECT promoted_columns_total FROM otlp_server_list() WHERE listen_uri = ?",
+        [f"otlp:127.0.0.1:{port}"],
+    ).fetchone()[0]
+    require(failures, promoted_total == 2, f"otlp_server_list promoted_columns_total={promoted_total} (expected 2)")
+
+    stopped = con.execute("SELECT status FROM otlp_stop(?)", [f"otlp:127.0.0.1:{port}"]).fetchone()[0]
+    require(failures, stopped.startswith("Stopped"), f"stop: {stopped}")
+    con.close()
+
+
+def main():
+    failures = []
+    try:
+        run(failures)
+    except Exception as exc:  # noqa: BLE001
+        failures.append(f"unhandled exception: {exc!r}")
+    print()
+    if failures:
+        print(f"FAILED ({len(failures)}):")
+        for f in failures:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("PASS")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/otlp_serve_promote.py
+++ b/test/manual/otlp_serve_promote.py
@@ -23,7 +23,9 @@ Run:
 
 import json
 import os
+import shutil
 import sys
+import tempfile
 import urllib.error
 import urllib.request
 
@@ -183,10 +185,91 @@ def run(failures):
     con.close()
 
 
+def connect_lake(lake):
+    con = duckdb.connect(config={"allow_unsigned_extensions": "true"})
+    con.execute(f"LOAD '{EXTENSION}'")
+    con.execute("LOAD ducklake")
+    meta = os.path.join(lake, "meta.ducklake")
+    data = os.path.join(lake, "data") + "/"
+    con.execute(f"ATTACH 'ducklake:{meta}' AS lake (DATA_PATH '{data}')")
+    return con
+
+
+def ingest_three(con, base_url, port):
+    for _ in range(3):
+        post(base_url + "/v1/logs", PAYLOAD)
+    return con.execute("SELECT status, error FROM otlp_flush(?)", [f"otlp:127.0.0.1:{port}"]).fetchone()
+
+
+def run_restart(failures):
+    # Regression test for restart against an already-promoted persisted catalog: the schema carries
+    # extra resource_attr_*/scope_attr_* columns, which startup validation must tolerate and the seal
+    # must populate (or NULL-fill when promotion is off). Uses a temp DuckLake so it runs every time.
+    lake = tempfile.mkdtemp(prefix="otlp_promote_restart_")
+    prefix = "lake.main."
+    promote = dict(promote_resource_attributes="host.name", promote_scope_attributes="scope.team")
+    try:
+        # Phase 1: serve with promotion, ingest 3, stop (persists 3 rows + promoted columns).
+        con = connect_lake(lake)
+        base = start_server(con, BASE_PORT + 10, catalog="lake", **promote)
+        ingest_three(con, base, BASE_PORT + 10)
+        con.execute("SELECT status FROM otlp_stop(?)", [f"otlp:127.0.0.1:{BASE_PORT + 10}"]).fetchone()
+        con.close()
+
+        # Phase 2: restart against the promoted catalog, same config — must start (the bug) and keep promoting.
+        con = connect_lake(lake)
+        started = True
+        try:
+            base = start_server(con, BASE_PORT + 11, catalog="lake", **promote)
+        except Exception as exc:  # noqa: BLE001
+            started = False
+            failures.append(f"restart with promotion failed to start: {exc!r}")
+        require(failures, started, "restart against promoted catalog starts")
+        if started:
+            ingest_three(con, base, BASE_PORT + 11)
+            total = con.execute(f"SELECT count(*) FROM {prefix}otlp_logs").fetchone()[0]
+            require(failures, total == 6, f"rows accumulate across restart ({total} == 6)")
+            populated = con.execute(
+                f"SELECT count(*) FROM {prefix}otlp_logs WHERE resource_attr_host_name = 'host-1'"
+            ).fetchone()[0]
+            require(failures, populated == 6, f"promotion continues after restart ({populated} == 6)")
+            con.execute("SELECT status FROM otlp_stop(?)", [f"otlp:127.0.0.1:{BASE_PORT + 11}"]).fetchone()
+        con.close()
+
+        # Phase 3: restart WITHOUT promotion config — ingest must still seal; the now-orphan promoted
+        # columns NULL-fill for the new rows (no Appender width mismatch on the wider table).
+        con = connect_lake(lake)
+        started3 = True
+        try:
+            base = start_server(con, BASE_PORT + 12, catalog="lake")
+        except Exception as exc:  # noqa: BLE001
+            started3 = False
+            failures.append(f"restart without promotion failed to start: {exc!r}")
+        require(failures, started3, "restart without promotion starts")
+        if started3:
+            flush = ingest_three(con, base, BASE_PORT + 12)
+            require(
+                failures,
+                flush[0] == "sealed" and not flush[1],
+                f"seal succeeds on wider table, promotion off ({flush})",
+            )
+            total = con.execute(f"SELECT count(*) FROM {prefix}otlp_logs").fetchone()[0]
+            require(failures, total == 9, f"rows ingested without promotion ({total} == 9)")
+            orphan_null = con.execute(
+                f"SELECT count(*) FROM {prefix}otlp_logs WHERE scope_attr_scope_team IS NULL"
+            ).fetchone()[0]
+            require(failures, orphan_null == 3, f"orphan promoted column NULL-filled for new rows ({orphan_null} == 3)")
+            con.execute("SELECT status FROM otlp_stop(?)", [f"otlp:127.0.0.1:{BASE_PORT + 12}"]).fetchone()
+        con.close()
+    finally:
+        shutil.rmtree(lake, ignore_errors=True)
+
+
 def main():
     failures = []
     try:
         run(failures)
+        run_restart(failures)
     except Exception as exc:  # noqa: BLE001
         failures.append(f"unhandled exception: {exc!r}")
     print()

--- a/test/server/test_server_config.py
+++ b/test/server/test_server_config.py
@@ -148,6 +148,31 @@ def test_otlp_limits_are_configurable(tmp_path):
     assert "maintenance_retention_ms := 600000" in result.stdout
 
 
+def test_promotion_params_emitted_when_set(tmp_path):
+    result = run(
+        {
+            "DUCKDB_MODE": "local-ducklake",
+            "DUCKDB_OTLP_TOKEN": "a-private-token-123456",
+            "DUCKDB_OTLP_PROMOTE_RESOURCE_ATTRIBUTES": "host.name,deployment.environment",
+            "DUCKDB_OTLP_PROMOTE_SCOPE_ATTRIBUTES": "scope.team",
+        },
+        tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "promote_resource_attributes := 'host.name,deployment.environment'" in result.stdout
+    assert "promote_scope_attributes := 'scope.team'" in result.stdout
+
+
+def test_promotion_off_by_default(tmp_path):
+    result = run(
+        {"DUCKDB_MODE": "local-ducklake", "DUCKDB_OTLP_TOKEN": "a-private-token-123456"},
+        tmp_path,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "promote_resource_attributes" not in result.stdout
+    assert "promote_scope_attributes" not in result.stdout
+
+
 def test_default_token_warns(tmp_path):
     result = run({"DUCKDB_MODE": "local-ducklake"}, tmp_path)  # no token set
     assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## What

Adds an opt-in option to `otlp_serve` / `otap_serve` that promotes **operator-specified** resource or scope attributes into first-class columns at ingest time:

```sql
SELECT * FROM otlp_serve('otlp:0.0.0.0:4318', catalog := 'lake',
    promote_resource_attributes := 'deployment.environment, k8s.namespace.name',
    promote_scope_attributes    := 'telemetry.sdk.name');
```

Resource/scope attributes land as JSON blobs, so filtering one is a full-scan `json_extract_string` with no row-group pruning. Promotion lifts named keys into `resource_attr_<key>` / `scope_attr_<key>` VARCHAR columns so attribute filters get per-row-group min/max stats. It's "Variant shredding" for a fixed, declared key set.

## How

- `OtlpColumnPromoter` resolves the key lists once; at server start it `LOAD json` + `ALTER TABLE ADD COLUMN IF NOT EXISTS` on all six signal tables (idempotent — restart is a no-op, so no metadata table). The catalog seal routes rows through a TEMP table and `INSERT ... SELECT *, json_extract_string(...) AS <col>` for the fixed set. **Flag-off keeps the existing fast `Appender` path unchanged.**
- The JSON blob is retained (the residual); reconstruct pre/post-promotion rows with `COALESCE(resource_attr_x, json_extract_string(resource_attributes, '$."x"'))`.
- **Catalog (DuckLake) mode only.** Best-effort: if `json` or `ALTER ADD COLUMN` is unavailable (e.g. an Iceberg catalog without add-column support), promotion self-disables with a log; ingest continues.
- Daemon env: `DUCKDB_OTLP_PROMOTE_RESOURCE_ATTRIBUTES` / `DUCKDB_OTLP_PROMOTE_SCOPE_ATTRIBUTES`.
- `otlp_server_list().promoted_columns_total` surfaces the count.

## Scope / non-goals

Resource and scope attributes only (not per-record log/span/metric attributes); VARCHAR only; no auto-discovery, thresholds, demotion, or blob dedup.

## Docs

- `reference/serve.md`: two params, the `promoted_columns_total` list column, and a new **Attribute promotion** section.
- Pointers from `reference/schemas.md` and `reference/performance.md`.

## Testing

- `test/manual/otlp_serve_promote.py` (new) — HTTP ingest e2e: resource + scope promoted and populated, COALESCE reconstructs (0 mismatches), metric correct, on **default and DuckLake** catalogs. ✅
- `test/server/test_server_config.py` — daemon env → `otlp_serve` SQL emission (+ off-by-default). ✅
- SQL suite 336/336; daemon config 16/16; extension + daemon builds clean; clang-format/black clean.

> Note: extraction uses DuckDB's `json` functions. The distroless daemon image does not yet cache the `json` extension, so on the daemon promotion self-disables until `json` is added to the deps-stage offline cache (build follow-up).

https://claude.ai/code/session_011bwL4viqjPuxP8K8YJCgD3